### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete URL scheme check

### DIFF
--- a/packages/core/src/lib/dom.js
+++ b/packages/core/src/lib/dom.js
@@ -140,7 +140,11 @@ export const validateUri = (name, value) => {
   }
 
   const normalized = value.replace(/\s+/g, '').toLowerCase()
-  if (normalized.startsWith('javascript:') || normalized.startsWith('vbscript:')) {
+  if (
+    normalized.startsWith('javascript:') ||
+    normalized.startsWith('vbscript:') ||
+    normalized.startsWith('data:')
+  ) {
     if (process.env.NODE_ENV !== 'production') {
       console.warn(`[Ryunix Security] Blocked dangerous ${name} URI: ${value}`)
     }


### PR DESCRIPTION
Potential fix for [https://github.com/UnSetSoft/Ryunixjs/security/code-scanning/6](https://github.com/UnSetSoft/Ryunixjs/security/code-scanning/6)

To fix the problem, the URL scheme validation should also reject `data:` URLs (after normalization) in addition to `javascript:` and `vbscript:`. This is done by extending the conditional in `validateUri` to include a `normalized.startsWith('data:')` check.

Concretely, in `packages/core/src/lib/dom.js`, within the `validateUri` function, update the `if` statement on line 143 so that it blocks three schemes instead of two. The rest of the logic (logging a warning in non-production and returning a safe placeholder URI like `javascript:void(0)`) can remain unchanged to avoid altering behavior beyond adding this extra protection. No new helper functions or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
