### PR TITLE
fix(core): resolve SSR RouterProvider pathname from globalThis.window

### DIFF
--- a/packages/core/src/lib/hooks.js
+++ b/packages/core/src/lib/hooks.js
@@ -464,6 +464,14 @@ const findRoute = (routes, path) => {
   return notFound
 }
 
+const getSsrPathname = () => {
+  const pathname = globalThis?.window?.location?.pathname
+  if (typeof pathname === 'string' && pathname) {
+    return pathname.split('?')[0].split('#')[0]
+  }
+  return '/'
+}
+
 /**
  * The `RouterProvider` component manages routing in a Ryunix application by updating the location based
  * on window events and providing context for the current route.
@@ -473,7 +481,7 @@ const findRoute = (routes, path) => {
 const RouterProvider = ({ routes, children }) => {
   // SSR: Return server-safe version without hooks
   if (typeof window === 'undefined') {
-    const location = '/'
+    const location = getSsrPathname()
     const currentRouteData = findRoute(routes, location) || {}
     const contextValue = {
       location,


### PR DESCRIPTION
## Summary

- Fix SSR/SSG render flash: `RouterProvider` no longer hardcodes `location` to `'/'` on the server.
- Read `globalThis.window.location.pathname` instead (mocked per route by SSG and dev SSR handlers) so prerendered HTML matches the client URL during hydration.

## Root cause

The preset sets `global.window.location.pathname` for each prerendered route, but the SSR branch of `RouterProvider` always resolved `/`. The client hydrated with the real pathname → hydration mismatch → container cleared → visible flash.

## Test plan

- [x] `pnpm --filter @unsetsoft/ryunixjs run build`
- [x] Run a doc site with `ssr: true` (e.g. `test/webpack` + `pnpm run:web`)
- [x] Open `/en/docs/introduction/getting-started` — content should remain visible after JS loads
- [x] Hard refresh on nested doc routes