### PR TITLE
test(vscode): add diagnostics fixtures and path-resolution coverage

### DIFF
--- a/packages/ryunix-vscode/scripts/bundle-client.mjs
+++ b/packages/ryunix-vscode/scripts/bundle-client.mjs
@@ -1,0 +1,13 @@
+import * as esbuild from 'esbuild'
+
+await esbuild.build({
+  entryPoints: ['src/extension.ts'],
+  bundle: true,
+  platform: 'node',
+  target: 'node18',
+  format: 'cjs',
+  outfile: 'out/extension.js',
+  external: ['vscode'],
+  packages: 'bundle',
+  logLevel: 'info',
+})

--- a/packages/ryunix-vscode/scripts/bundle-server.mjs
+++ b/packages/ryunix-vscode/scripts/bundle-server.mjs
@@ -1,0 +1,13 @@
+import * as esbuild from 'esbuild'
+
+await esbuild.build({
+  entryPoints: ['server/src/server.ts'],
+  bundle: true,
+  platform: 'node',
+  target: 'node18',
+  format: 'cjs',
+  outfile: 'server/out/server.js',
+  /** Runtime dependency — avoids bundling source-map-support / legacy Buffer paths */
+  external: ['typescript'],
+  logLevel: 'info',
+})

--- a/packages/ryunix-vscode/server/src/diagnostic-filters.ts
+++ b/packages/ryunix-vscode/server/src/diagnostic-filters.ts
@@ -133,9 +133,7 @@ export function resolveModuleSpecifier(
   }
 
   if (moduleSpecifier.startsWith('.')) {
-    const fromDir = fromFile
-      ? path.dirname(normalizePath(fromFile))
-      : baseUrl
+    const fromDir = fromFile ? path.dirname(normalizePath(fromFile)) : baseUrl
     return tryResolveFile(path.join(fromDir, moduleSpecifier))
   }
 
@@ -144,7 +142,11 @@ export function resolveModuleSpecifier(
 
 export function isBundlerResolvedImport(spec: string): boolean {
   if (ASSET_MODULE.test(spec)) return true
-  if (spec.startsWith('@/') || spec.startsWith('./') || spec.startsWith('../')) {
+  if (
+    spec.startsWith('@/') ||
+    spec.startsWith('./') ||
+    spec.startsWith('../')
+  ) {
     return true
   }
   return RESOLVE_EXTENSIONS.some((ext) => spec.endsWith(ext))

--- a/packages/ryunix-vscode/server/src/diagnostic-filters.ts
+++ b/packages/ryunix-vscode/server/src/diagnostic-filters.ts
@@ -1,0 +1,218 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import ts from 'typescript'
+
+/** Webpack asset imports handled by file-loader / asset modules. */
+const ASSET_MODULE =
+  /\.(svg|png|jpe?g|gif|webp|ico|avif|bmp|mp4|webm|woff2?|ttf|eot|mp3|wav|css|scss|sass|less)(\?.*)?$/i
+
+/** Ryunix / webpack script resolution order (see ryunix-presets webpack.config). */
+const RESOLVE_EXTENSIONS = [
+  '.ryx',
+  '.js',
+  '.jsx',
+  '.ts',
+  '.tsx',
+  '.mjs',
+  '.cjs',
+]
+
+const MODULE_NOT_FOUND = 2307
+
+function normalizePath(filePath: string): string {
+  try {
+    return fs.realpathSync.native(path.resolve(filePath))
+  } catch {
+    return path.resolve(filePath)
+  }
+}
+
+function flattenMessage(message: ts.DiagnosticMessageChain | string): string {
+  if (typeof message === 'string') return message
+  let out = message.messageText
+  for (const next of message.next ?? []) {
+    out += flattenMessage(next)
+  }
+  return out
+}
+
+function moduleSpecifierFromDiagnostic(d: ts.Diagnostic): string | undefined {
+  if (d.code !== MODULE_NOT_FOUND) return undefined
+  const text = flattenMessage(d.messageText)
+  const quoted = text.match(/Cannot find module '([^']+)'/)
+  if (quoted) return quoted[1]
+  const unquoted = text.match(/Cannot find module ([^\s]+)/)
+  return unquoted?.[1]
+}
+
+function isExistingFile(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile()
+  } catch {
+    return false
+  }
+}
+
+/** Match webpack resolve: explicit path, extension suffix, or directory/index.* */
+function tryResolveFile(candidate: string): string | undefined {
+  const normalized = normalizePath(candidate)
+  if (isExistingFile(normalized)) return normalized
+
+  const ext = path.extname(normalized)
+  if (!ext) {
+    for (const suffix of RESOLVE_EXTENSIONS) {
+      const withExt = normalized + suffix
+      if (isExistingFile(withExt)) return withExt
+    }
+    for (const suffix of RESOLVE_EXTENSIONS) {
+      const indexFile = path.join(normalized, `index${suffix}`)
+      if (isExistingFile(indexFile)) return indexFile
+    }
+  }
+
+  return undefined
+}
+
+function resolveBaseUrl(
+  projectRoot: string,
+  options: ts.CompilerOptions,
+): string {
+  if (!options.baseUrl) return normalizePath(projectRoot)
+  if (path.isAbsolute(options.baseUrl)) {
+    return normalizePath(options.baseUrl)
+  }
+  return normalizePath(path.join(projectRoot, options.baseUrl))
+}
+
+/** Resolve tsconfig paths + baseUrl the same way Ryunix webpack aliases work. */
+export function resolveModuleSpecifier(
+  moduleSpecifier: string,
+  projectRoot: string,
+  options: ts.CompilerOptions,
+  fromFile?: string,
+): string | undefined {
+  const baseUrl = resolveBaseUrl(projectRoot, options)
+
+  const paths = options.paths ?? {}
+
+  const resolveMapped = (mapped: string): string | undefined => {
+    return tryResolveFile(path.join(baseUrl, mapped))
+  }
+
+  for (const [pattern, targets] of Object.entries(paths)) {
+    const star = pattern.indexOf('*')
+    if (star === -1) {
+      if (pattern !== moduleSpecifier) continue
+      for (const target of targets) {
+        const hit = resolveMapped(target)
+        if (hit) return hit
+      }
+      continue
+    }
+
+    const prefix = pattern.slice(0, star)
+    const suffix = pattern.slice(star + 1)
+    if (!moduleSpecifier.startsWith(prefix)) continue
+    if (suffix && !moduleSpecifier.endsWith(suffix)) continue
+
+    let matched = moduleSpecifier.slice(
+      prefix.length,
+      suffix ? moduleSpecifier.length - suffix.length : undefined,
+    )
+    if (matched.startsWith('/')) matched = matched.slice(1)
+
+    for (const target of targets) {
+      const tStar = target.indexOf('*')
+      const mapped =
+        tStar === -1
+          ? target
+          : target.slice(0, tStar) + matched + target.slice(tStar + 1)
+      const hit = resolveMapped(mapped)
+      if (hit) return hit
+    }
+  }
+
+  if (moduleSpecifier.startsWith('.')) {
+    const fromDir = fromFile
+      ? path.dirname(normalizePath(fromFile))
+      : baseUrl
+    return tryResolveFile(path.join(fromDir, moduleSpecifier))
+  }
+
+  return undefined
+}
+
+export function isBundlerResolvedImport(spec: string): boolean {
+  if (ASSET_MODULE.test(spec)) return true
+  if (spec.startsWith('@/') || spec.startsWith('./') || spec.startsWith('../')) {
+    return true
+  }
+  return RESOLVE_EXTENSIONS.some((ext) => spec.endsWith(ext))
+}
+
+const JSX_INVALID_ELEMENT = 2604
+const JSX_GLOBAL_NAME_COLLISION = new Set([
+  'Image',
+  'Event',
+  'History',
+  'Location',
+  'Navigator',
+  'Screen',
+  'Option',
+])
+
+function jsxTagFromDiagnostic(d: ts.Diagnostic): string | undefined {
+  if (d.code !== JSX_INVALID_ELEMENT || !d.file || d.start === undefined) {
+    return undefined
+  }
+  const text = d.file.getFullText()
+  const line = d.file.getLineAndCharacterOfPosition(d.start).line
+  const lineStart = d.file.getPositionOfLineAndCharacter(line, 0)
+  const nextLine = d.file.getPositionOfLineAndCharacter(line + 1, 0)
+  const lineText = text.slice(lineStart, nextLine)
+  const match = lineText.match(/<([A-Z][A-Za-z0-9]*)/)
+  return match?.[1]
+}
+
+/**
+ * Drop TS2307 when webpack/Ryunix would resolve the module (assets, .ryx, alias paths).
+ * Drop TS2604 for capitalized tags that collide with browser globals when unimported.
+ */
+export function filterFalsePositiveModuleDiagnostics(
+  diagnostics: ts.Diagnostic[],
+  projectRoot: string,
+  options: ts.CompilerOptions,
+  entrySource?: ts.SourceFile,
+): ts.Diagnostic[] {
+  const importedNames = new Set<string>()
+  if (entrySource) {
+    entrySource.statements.forEach((stmt) => {
+      if (!ts.isImportDeclaration(stmt) || !stmt.importClause) return
+      const clause = stmt.importClause
+      if (clause.name) importedNames.add(clause.name.text)
+      if (clause.namedBindings && ts.isNamedImports(clause.namedBindings)) {
+        for (const el of clause.namedBindings.elements) {
+          importedNames.add(el.name.text)
+        }
+      }
+    })
+  }
+
+  return diagnostics.filter((d) => {
+    if (d.code === JSX_INVALID_ELEMENT) {
+      const tag = jsxTagFromDiagnostic(d)
+      if (
+        tag &&
+        JSX_GLOBAL_NAME_COLLISION.has(tag) &&
+        !importedNames.has(tag)
+      ) {
+        return false
+      }
+    }
+
+    const spec = moduleSpecifierFromDiagnostic(d)
+    if (!spec || !isBundlerResolvedImport(spec)) return true
+    const resolved = resolveModuleSpecifier(spec, projectRoot, options)
+    return !resolved
+  })
+}

--- a/packages/ryunix-vscode/server/src/ryunix-config-paths.ts
+++ b/packages/ryunix-vscode/server/src/ryunix-config-paths.ts
@@ -1,0 +1,64 @@
+import { createRequire } from 'module'
+import * as fs from 'fs'
+import * as path from 'path'
+
+/** Map webpack.resolve.alias entries to TypeScript compilerOptions.paths. */
+export function pathsFromRyunixConfig(
+  projectDir: string,
+): Record<string, string[]> {
+  const cfgPath = path.join(projectDir, 'ryunix.config.js')
+  if (!fs.existsSync(cfgPath)) return {}
+
+  try {
+    const req = createRequire(cfgPath)
+    const loaded = req(cfgPath) as { default?: unknown } | unknown
+    const config = (
+      loaded && typeof loaded === 'object' && 'default' in loaded
+        ? loaded.default
+        : loaded
+    ) as {
+      webpack?: { resolve?: { alias?: Record<string, string> } }
+    }
+
+    const alias = config?.webpack?.resolve?.alias
+    if (!alias || typeof alias !== 'object') return {}
+
+    const paths: Record<string, string[]> = {}
+    for (const [key, value] of Object.entries(alias)) {
+      if (typeof value !== 'string') continue
+      const tsKey = key.endsWith('/*') ? key : `${key}/*`
+      let rel = value.replace(/^\.\//, '')
+      if (path.isAbsolute(value)) {
+        rel = path.relative(projectDir, value).replace(/\\/g, '/')
+        if (!rel || rel === '') rel = '.'
+      }
+      paths[tsKey] = [rel.endsWith('/*') ? rel : `${rel}/*`]
+    }
+    return paths
+  } catch {
+    return {}
+  }
+}
+
+export function mergeCompilerPaths(
+  base: Record<string, string[]>,
+  extra: Record<string, string[]>,
+): Record<string, string[]> {
+  const merged = { ...base }
+  for (const [key, value] of Object.entries(extra)) {
+    if (merged[key]) continue
+    merged[key] = value
+  }
+  return merged
+}
+
+/** True when jsconfig/tsconfig already defines a path prefix. */
+export function hasPathPrefix(
+  paths: Record<string, string[]>,
+  prefix: string,
+): boolean {
+  const normalized = prefix.endsWith('/*') ? prefix : `${prefix}/*`
+  return Object.keys(paths).some(
+    (k) => k === prefix || k === normalized || k.startsWith(`${prefix}/`),
+  )
+}

--- a/packages/ryunix-vscode/server/src/ryunix-types-resolve.ts
+++ b/packages/ryunix-vscode/server/src/ryunix-types-resolve.ts
@@ -1,0 +1,57 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+const RYUNIX_PKG = '@unsetsoft/ryunixjs'
+
+function readPackageName(pkgPath: string): string | undefined {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { name?: string }
+    return pkg.name
+  } catch {
+    return undefined
+  }
+}
+
+/** Absolute path to `types/index.d.ts` for @unsetsoft/ryunixjs (node_modules or monorepo core). */
+export function resolveRyunixTypesEntry(projectRoot: string): string | undefined {
+  const searchRoots = new Set<string>()
+  let dir = path.resolve(projectRoot)
+
+  for (let i = 0; i < 10; i++) {
+    searchRoots.add(dir)
+    const parent = path.dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+
+  for (const root of searchRoots) {
+    const fromNodeModules = path.join(
+      root,
+      'node_modules',
+      RYUNIX_PKG,
+      'types',
+      'index.d.ts',
+    )
+    if (fs.existsSync(fromNodeModules)) return fromNodeModules
+
+    const corePkg = path.join(root, 'packages', 'core', 'package.json')
+    const coreTypes = path.join(root, 'packages', 'core', 'types', 'index.d.ts')
+    if (fs.existsSync(coreTypes) && readPackageName(corePkg) === RYUNIX_PKG) {
+      return coreTypes
+    }
+  }
+
+  return undefined
+}
+
+/** compilerOptions.paths entry relative to projectRoot baseUrl. */
+export function ryunixTypesPathEntries(
+  projectRoot: string,
+): string[] | undefined {
+  const entry = resolveRyunixTypesEntry(projectRoot)
+  if (!entry) return undefined
+
+  const rel = path.relative(path.resolve(projectRoot), entry).replace(/\\/g, '/')
+  if (!rel || rel.startsWith('..')) return [entry]
+  return [rel.startsWith('.') ? rel : `./${rel}`]
+}

--- a/packages/ryunix-vscode/server/src/ryunix-types-resolve.ts
+++ b/packages/ryunix-vscode/server/src/ryunix-types-resolve.ts
@@ -5,7 +5,9 @@ const RYUNIX_PKG = '@unsetsoft/ryunixjs'
 
 function readPackageName(pkgPath: string): string | undefined {
   try {
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { name?: string }
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as {
+      name?: string
+    }
     return pkg.name
   } catch {
     return undefined
@@ -13,7 +15,9 @@ function readPackageName(pkgPath: string): string | undefined {
 }
 
 /** Absolute path to `types/index.d.ts` for @unsetsoft/ryunixjs (node_modules or monorepo core). */
-export function resolveRyunixTypesEntry(projectRoot: string): string | undefined {
+export function resolveRyunixTypesEntry(
+  projectRoot: string,
+): string | undefined {
   const searchRoots = new Set<string>()
   let dir = path.resolve(projectRoot)
 
@@ -51,7 +55,9 @@ export function ryunixTypesPathEntries(
   const entry = resolveRyunixTypesEntry(projectRoot)
   if (!entry) return undefined
 
-  const rel = path.relative(path.resolve(projectRoot), entry).replace(/\\/g, '/')
+  const rel = path
+    .relative(path.resolve(projectRoot), entry)
+    .replace(/\\/g, '/')
   if (!rel || rel.startsWith('..')) return [entry]
   return [rel.startsWith('.') ? rel : `./${rel}`]
 }

--- a/packages/ryunix-vscode/server/src/virtual-program.ts
+++ b/packages/ryunix-vscode/server/src/virtual-program.ts
@@ -1,0 +1,98 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import ts from 'typescript'
+import { resolveModuleSpecifier } from './diagnostic-filters'
+
+const RYX_EXT = /\.ryx$/i
+
+function normalizePath(filePath: string): string {
+  try {
+    return fs.realpathSync.native(path.resolve(filePath))
+  } catch {
+    return path.resolve(filePath)
+  }
+}
+
+/** Static import specifiers in a source file. */
+export function collectModuleSpecifiers(sourceFile: ts.SourceFile): string[] {
+  const specs: string[] = []
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isImportDeclaration(node) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      specs.push(node.moduleSpecifier.text)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return specs
+}
+
+export interface VirtualRyxSource {
+  virtualPath: string
+  ryxPath: string
+  sourceFile: ts.SourceFile
+}
+
+/** Virtual `.tsx` sources for entry `.ryx` and resolved `.ryx` imports. */
+export function buildVirtualRyxProgramSources(
+  entryRyxPath: string,
+  entryContent: string,
+  projectRoot: string,
+  options: ts.CompilerOptions,
+  readFile: (ryxPath: string) => string,
+  maxDepth = 6,
+): VirtualRyxSource[] {
+  const out: VirtualRyxSource[] = []
+  const seenRyx = new Set<string>()
+  const queue: Array<{ ryxPath: string; content: string; depth: number }> = [
+    { ryxPath: normalizePath(entryRyxPath), content: entryContent, depth: 0 },
+  ]
+
+  while (queue.length > 0) {
+    const current = queue.shift()!
+    if (seenRyx.has(current.ryxPath)) continue
+    seenRyx.add(current.ryxPath)
+
+    const virtualPath = current.ryxPath.replace(RYX_EXT, '.tsx')
+    const sourceFile = ts.createSourceFile(
+      virtualPath,
+      current.content,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TSX,
+    )
+    out.push({
+      virtualPath: normalizePath(virtualPath),
+      ryxPath: current.ryxPath,
+      sourceFile,
+    })
+
+    if (current.depth >= maxDepth) continue
+
+    for (const spec of collectModuleSpecifiers(sourceFile)) {
+      const resolved = resolveModuleSpecifier(
+        spec,
+        projectRoot,
+        options,
+        current.ryxPath,
+      )
+      if (!resolved || !RYX_EXT.test(resolved) || seenRyx.has(resolved)) continue
+      queue.push({
+        ryxPath: resolved,
+        content: readFile(resolved),
+        depth: current.depth + 1,
+      })
+    }
+  }
+
+  return out
+}
+
+export function virtualSourceMap(
+  sources: VirtualRyxSource[],
+): Map<string, ts.SourceFile> {
+  return new Map(sources.map((s) => [s.virtualPath, s.sourceFile]))
+}

--- a/packages/ryunix-vscode/server/src/virtual-program.ts
+++ b/packages/ryunix-vscode/server/src/virtual-program.ts
@@ -79,7 +79,8 @@ export function buildVirtualRyxProgramSources(
         options,
         current.ryxPath,
       )
-      if (!resolved || !RYX_EXT.test(resolved) || seenRyx.has(resolved)) continue
+      if (!resolved || !RYX_EXT.test(resolved) || seenRyx.has(resolved))
+        continue
       queue.push({
         ryxPath: resolved,
         content: readFile(resolved),

--- a/packages/ryunix-vscode/snippets/file-templates.code-snippets
+++ b/packages/ryunix-vscode/snippets/file-templates.code-snippets
@@ -16,9 +16,9 @@
       "\t\t\t${4}",
       "\t\t</main>",
       "\t)",
-      "}"
+      "}",
     ],
-    "description": "Full route page template for index.ryx (Metatags + default export)"
+    "description": "Full route page template for index.ryx (Metatags + default export)",
   },
   "Ryunix layout (layout.ryx)": {
     "prefix": "ryx-layout",
@@ -36,9 +36,9 @@
       "",
       "export default function ${3:RootLayout}({ children }) {",
       "\treturn children",
-      "}"
+      "}",
     ],
-    "description": "Root layout template for layout.ryx"
+    "description": "Root layout template for layout.ryx",
   },
   "Ryunix errors (errors.ryx)": {
     "prefix": "ryx-errors",
@@ -52,9 +52,9 @@
       "\t\t\t<a href=\"/\">${4:Go back home}</a>",
       "\t\t</main>",
       "\t)",
-      "}"
+      "}",
     ],
-    "description": "Global not-found template for errors.ryx"
+    "description": "Global not-found template for errors.ryx",
   },
   "Ryunix loading (loading.ryx)": {
     "prefix": "ryx-loading",
@@ -66,9 +66,9 @@
       "\t\t\t<p>${2:Loading…}</p>",
       "\t\t</div>",
       "\t)",
-      "}"
+      "}",
     ],
-    "description": "Route loading UI template for loading.ryx"
+    "description": "Route loading UI template for loading.ryx",
   },
   "Ryunix route error (error.ryx)": {
     "prefix": "ryx-error",
@@ -82,9 +82,9 @@
       "\t\t\t<button type=\"button\" onClick={reset}>${3:Try again}</button>",
       "\t\t</main>",
       "\t)",
-      "}"
+      "}",
     ],
-    "description": "Per-route error boundary template for error.ryx"
+    "description": "Per-route error boundary template for error.ryx",
   },
   "Ryunix server page (async index.ryx)": {
     "prefix": "ryx-server-page",
@@ -104,8 +104,8 @@
       "\t\t\t${5}",
       "\t\t</main>",
       "\t)",
-      "}"
+      "}",
     ],
-    "description": "Async server page template for index.ryx"
-  }
+    "description": "Async server page template for index.ryx",
+  },
 }

--- a/packages/ryunix-vscode/snippets/file-templates.code-snippets
+++ b/packages/ryunix-vscode/snippets/file-templates.code-snippets
@@ -1,0 +1,111 @@
+{
+  "Ryunix page (index.ryx)": {
+    "prefix": "ryx-page",
+    "isFileTemplate": true,
+    "body": [
+      "export const Metatags = {",
+      "\ttitle: \"${1:Page title}\",",
+      "\tdescription: '${2:Description}',",
+      "\tviewport: 'width=device-width, initial-scale=1.0',",
+      "\tcharset: 'UTF-8',",
+      "}",
+      "",
+      "export default function ${3:Page}() {",
+      "\treturn (",
+      "\t\t<main>",
+      "\t\t\t${4}",
+      "\t\t</main>",
+      "\t)",
+      "}"
+    ],
+    "description": "Full route page template for index.ryx (Metatags + default export)"
+  },
+  "Ryunix layout (layout.ryx)": {
+    "prefix": "ryx-layout",
+    "isFileTemplate": true,
+    "body": [
+      "export const Metatags = {",
+      "\ttitle: {",
+      "\t\ttemplate: '%s | ${1:App name}',",
+      "\t\tdefault: '${1:App name}',",
+      "\t},",
+      "\tdescription: '${2:Description}',",
+      "\tviewport: 'width=device-width, initial-scale=1.0',",
+      "\tcharset: 'UTF-8',",
+      "}",
+      "",
+      "export default function ${3:RootLayout}({ children }) {",
+      "\treturn children",
+      "}"
+    ],
+    "description": "Root layout template for layout.ryx"
+  },
+  "Ryunix errors (errors.ryx)": {
+    "prefix": "ryx-errors",
+    "isFileTemplate": true,
+    "body": [
+      "export default function ${1:NotFound}() {",
+      "\treturn (",
+      "\t\t<main>",
+      "\t\t\t<h1>${2:404}</h1>",
+      "\t\t\t<p>${3:Page not found}</p>",
+      "\t\t\t<a href=\"/\">${4:Go back home}</a>",
+      "\t\t</main>",
+      "\t)",
+      "}"
+    ],
+    "description": "Global not-found template for errors.ryx"
+  },
+  "Ryunix loading (loading.ryx)": {
+    "prefix": "ryx-loading",
+    "isFileTemplate": true,
+    "body": [
+      "export default function ${1:Loading}() {",
+      "\treturn (",
+      "\t\t<div className=\"loading\">",
+      "\t\t\t<p>${2:Loading…}</p>",
+      "\t\t</div>",
+      "\t)",
+      "}"
+    ],
+    "description": "Route loading UI template for loading.ryx"
+  },
+  "Ryunix route error (error.ryx)": {
+    "prefix": "ryx-error",
+    "isFileTemplate": true,
+    "body": [
+      "export default function ${1:RouteError}({ error, reset }) {",
+      "\treturn (",
+      "\t\t<main>",
+      "\t\t\t<h1>${2:Something went wrong}</h1>",
+      "\t\t\t<p>{error?.message}</p>",
+      "\t\t\t<button type=\"button\" onClick={reset}>${3:Try again}</button>",
+      "\t\t</main>",
+      "\t)",
+      "}"
+    ],
+    "description": "Per-route error boundary template for error.ryx"
+  },
+  "Ryunix server page (async index.ryx)": {
+    "prefix": "ryx-server-page",
+    "isFileTemplate": true,
+    "body": [
+      "export const Metatags = {",
+      "\ttitle: \"${1:Page title}\",",
+      "\tdescription: '${2:Description}',",
+      "\tviewport: 'width=device-width, initial-scale=1.0',",
+      "\tcharset: 'UTF-8',",
+      "}",
+      "",
+      "export default async function ${3:Page}() {",
+      "\t${4:// fetch data on the server}",
+      "\treturn (",
+      "\t\t<main>",
+      "\t\t\t${5}",
+      "\t\t</main>",
+      "\t)",
+      "}"
+    ],
+    "description": "Async server page template for index.ryx"
+  }
+}

--- a/packages/ryunix-vscode/snippets/ryunix-api.code-snippets
+++ b/packages/ryunix-vscode/snippets/ryunix-api.code-snippets
@@ -1,0 +1,27 @@
+{
+  "Ryunix API GET handler": {
+    "prefix": "ryx-api-get",
+    "body": [
+      "export const GET = async (req) => {",
+      "\treturn new Response(JSON.stringify({ ${1:message}: '${2:Hello}' } }), {",
+      "\t\tstatus: 200,",
+      "\t\theaders: { 'Content-Type': 'application/json' },",
+      "\t})",
+      "}"
+    ],
+    "description": "API route GET handler for router.js"
+  },
+  "Ryunix API POST handler": {
+    "prefix": "ryx-api-post",
+    "body": [
+      "export const POST = async (req) => {",
+      "\tconst body = await req.json()",
+      "\treturn new Response(JSON.stringify({ ${1:ok}: true }), {",
+      "\t\tstatus: 200,",
+      "\t\theaders: { 'Content-Type': 'application/json' },",
+      "\t})",
+      "}"
+    ],
+    "description": "API route POST handler for router.js"
+  }
+}

--- a/packages/ryunix-vscode/snippets/ryunix-api.code-snippets
+++ b/packages/ryunix-vscode/snippets/ryunix-api.code-snippets
@@ -7,9 +7,9 @@
       "\t\tstatus: 200,",
       "\t\theaders: { 'Content-Type': 'application/json' },",
       "\t})",
-      "}"
+      "}",
     ],
-    "description": "API route GET handler for router.js"
+    "description": "API route GET handler for router.js",
   },
   "Ryunix API POST handler": {
     "prefix": "ryx-api-post",
@@ -20,8 +20,8 @@
       "\t\tstatus: 200,",
       "\t\theaders: { 'Content-Type': 'application/json' },",
       "\t})",
-      "}"
+      "}",
     ],
-    "description": "API route POST handler for router.js"
-  }
+    "description": "API route POST handler for router.js",
+  },
 }

--- a/packages/ryunix-vscode/snippets/ryunix-component.code-snippets
+++ b/packages/ryunix-vscode/snippets/ryunix-component.code-snippets
@@ -8,8 +8,8 @@
       "\t\t\t${3}",
       "\t\t</>",
       "\t)",
-      "}"
+      "}",
     ],
-    "description": "Default export component with JSX return"
-  }
+    "description": "Default export component with JSX return",
+  },
 }

--- a/packages/ryunix-vscode/snippets/ryunix-component.code-snippets
+++ b/packages/ryunix-vscode/snippets/ryunix-component.code-snippets
@@ -1,0 +1,15 @@
+{
+  "Ryunix component": {
+    "prefix": "ryx-component",
+    "body": [
+      "export default function ${1:Component}(${2:props}) {",
+      "\treturn (",
+      "\t\t<>",
+      "\t\t\t${3}",
+      "\t\t</>",
+      "\t)",
+      "}"
+    ],
+    "description": "Default export component with JSX return"
+  }
+}

--- a/packages/ryunix-vscode/snippets/ryunix-imports.code-snippets
+++ b/packages/ryunix-vscode/snippets/ryunix-imports.code-snippets
@@ -1,0 +1,19 @@
+{
+  "Import from Ryunix core": {
+    "prefix": "ryx-import",
+    "body": ["import { ${1:useStore} } from '@unsetsoft/ryunixjs'"],
+    "description": "Import hooks or components from @unsetsoft/ryunixjs"
+  },
+  "Ryunix Metatags export": {
+    "prefix": "ryx-metatags",
+    "body": [
+      "export const Metatags = {",
+      "\ttitle: \"${1:Page title}\",",
+      "\tdescription: '${2:Description}',",
+      "\tviewport: 'width=device-width, initial-scale=1.0',",
+      "\tcharset: 'UTF-8',",
+      "}"
+    ],
+    "description": "SEO Metatags object for a route"
+  }
+}

--- a/packages/ryunix-vscode/snippets/ryunix-imports.code-snippets
+++ b/packages/ryunix-vscode/snippets/ryunix-imports.code-snippets
@@ -2,7 +2,7 @@
   "Import from Ryunix core": {
     "prefix": "ryx-import",
     "body": ["import { ${1:useStore} } from '@unsetsoft/ryunixjs'"],
-    "description": "Import hooks or components from @unsetsoft/ryunixjs"
+    "description": "Import hooks or components from @unsetsoft/ryunixjs",
   },
   "Ryunix Metatags export": {
     "prefix": "ryx-metatags",
@@ -12,8 +12,8 @@
       "\tdescription: '${2:Description}',",
       "\tviewport: 'width=device-width, initial-scale=1.0',",
       "\tcharset: 'UTF-8',",
-      "}"
+      "}",
     ],
-    "description": "SEO Metatags object for a route"
-  }
+    "description": "SEO Metatags object for a route",
+  },
 }

--- a/packages/ryunix-vscode/snippets/ryunix-jsx.code-snippets
+++ b/packages/ryunix-vscode/snippets/ryunix-jsx.code-snippets
@@ -2,25 +2,25 @@
   "Ryunix Link (inline JSX)": {
     "prefix": "link",
     "body": ["<Link to=\"${1:/}\">${2:Home}</Link>"],
-    "description": "Inline Link component (import Link separately with ryx-import)"
+    "description": "Inline Link component (import Link separately with ryx-import)",
   },
   "Ryunix Link (deprecated alias)": {
     "prefix": "ryx-link",
     "body": ["<Link to=\"${1:/}\">${2:Home}</Link>"],
-    "description": "Deprecated alias for link — use ryx-import + link snippet"
+    "description": "Deprecated alias for link — use ryx-import + link snippet",
   },
   "Ryunix NavLink (inline JSX)": {
     "prefix": "navlink",
     "body": [
-      "<NavLink to=\"${1:/}\" className=\"${2:}\" exact={${3:false}}>${4:Link}</NavLink>"
+      "<NavLink to=\"${1:/}\" className=\"${2:}\" exact={${3:false}}>${4:Link}</NavLink>",
     ],
-    "description": "Inline NavLink (import NavLink separately with ryx-import)"
+    "description": "Inline NavLink (import NavLink separately with ryx-import)",
   },
   "Ryunix NavLink (deprecated alias)": {
     "prefix": "ryx-navlink",
     "body": [
-      "<NavLink to=\"${1:/}\" className=\"${2:}\" exact={${3:false}}>${4:Link}</NavLink>"
+      "<NavLink to=\"${1:/}\" className=\"${2:}\" exact={${3:false}}>${4:Link}</NavLink>",
     ],
-    "description": "Deprecated alias for navlink — use ryx-import + navlink snippet"
-  }
+    "description": "Deprecated alias for navlink — use ryx-import + navlink snippet",
+  },
 }

--- a/packages/ryunix-vscode/snippets/ryunix-jsx.code-snippets
+++ b/packages/ryunix-vscode/snippets/ryunix-jsx.code-snippets
@@ -1,0 +1,26 @@
+{
+  "Ryunix Link (inline JSX)": {
+    "prefix": "link",
+    "body": ["<Link to=\"${1:/}\">${2:Home}</Link>"],
+    "description": "Inline Link component (import Link separately with ryx-import)"
+  },
+  "Ryunix Link (deprecated alias)": {
+    "prefix": "ryx-link",
+    "body": ["<Link to=\"${1:/}\">${2:Home}</Link>"],
+    "description": "Deprecated alias for link — use ryx-import + link snippet"
+  },
+  "Ryunix NavLink (inline JSX)": {
+    "prefix": "navlink",
+    "body": [
+      "<NavLink to=\"${1:/}\" className=\"${2:}\" exact={${3:false}}>${4:Link}</NavLink>"
+    ],
+    "description": "Inline NavLink (import NavLink separately with ryx-import)"
+  },
+  "Ryunix NavLink (deprecated alias)": {
+    "prefix": "ryx-navlink",
+    "body": [
+      "<NavLink to=\"${1:/}\" className=\"${2:}\" exact={${3:false}}>${4:Link}</NavLink>"
+    ],
+    "description": "Deprecated alias for navlink — use ryx-import + navlink snippet"
+  }
+}

--- a/packages/ryunix-vscode/test/diagnostics.test.cjs
+++ b/packages/ryunix-vscode/test/diagnostics.test.cjs
@@ -1,0 +1,86 @@
+/**
+ * Diagnostic smoke tests for RyunixTsProgram.
+ */
+const path = require('path')
+const fs = require('fs')
+
+const { RyunixTsProgram } = require('../server/out/ts-program')
+
+function fixtureRoot(name) {
+  return path.join(__dirname, 'fixtures', 'diagnostics', name)
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function main() {
+  const root = fixtureRoot('')
+  const extTypes = path.join(__dirname, '..')
+  const program = new RyunixTsProgram(root, extTypes, { checkJsOverride: true })
+
+  const syntaxFile = path.join(root, 'syntax-error.ryx')
+  const syntaxContent = fs.readFileSync(syntaxFile, 'utf8')
+  program.syncOpenDocument(syntaxFile, syntaxContent)
+  const syntaxDiags = program.getDiagnostics(syntaxFile)
+  assert(
+    syntaxDiags.length > 0,
+    `syntax-error.ryx should produce at least one diagnostic, got ${syntaxDiags.length}`,
+  )
+
+  const badImportFile = path.join(root, 'bad-import.ryx')
+  const badImportContent = fs.readFileSync(badImportFile, 'utf8')
+  program.syncOpenDocument(badImportFile, badImportContent)
+  const importDiags = program.getDiagnostics(badImportFile)
+  assert(
+    importDiags.length > 0,
+    'bad-import.ryx should produce semantic diagnostics with checkJs enabled',
+  )
+
+  const assetFile = path.join(root, 'asset-import.ryx')
+  const assetContent = fs.readFileSync(assetFile, 'utf8')
+  program.syncOpenDocument(assetFile, assetContent)
+  const assetDiags = program.getDiagnostics(assetFile)
+  const asset2307 = assetDiags.filter((d) => d.code === 2307)
+  assert(
+    asset2307.length === 0,
+    `asset-import.ryx should not report false TS2307 for existing @/ SVG, got: ${asset2307.map((d) => String(d.messageText)).join('; ')}`,
+  )
+
+  for (const name of ['ryx-import-ext.ryx', 'ryx-import-no-ext.ryx']) {
+    const file = path.join(root, name)
+    program.syncOpenDocument(file, fs.readFileSync(file, 'utf8'))
+    const diags = program.getDiagnostics(file).filter((d) => d.code === 2307)
+    assert(
+      diags.length === 0,
+      `${name} should resolve @/components/ui/Icon(.ryx), got: ${diags.map((d) => String(d.messageText)).join('; ')}`,
+    )
+  }
+
+  const imageFile = path.join(root, 'image-jsx.ryx')
+  program.syncOpenDocument(imageFile, fs.readFileSync(imageFile, 'utf8'))
+  const imageDiags = program.getDiagnostics(imageFile)
+  const image2604 = imageDiags.filter((d) => d.code === 2604)
+  assert(
+    image2604.length === 0,
+    `image-jsx.ryx should allow <Image /> when imported from .ryx, got: ${image2604.map((d) => String(d.messageText)).join('; ')}`,
+  )
+
+  const namedImportsFile = path.join(root, 'ryunix-named-imports.ryx')
+  program.syncOpenDocument(
+    namedImportsFile,
+    fs.readFileSync(namedImportsFile, 'utf8'),
+  )
+  const namedDiags = program.getDiagnostics(namedImportsFile)
+  const missingExport = namedDiags.filter(
+    (d) => d.code === 2305 || d.code === 2614,
+  )
+  assert(
+    missingExport.length === 0,
+    `named imports from @unsetsoft/ryunixjs should resolve (useRouter, useStore, Link), got: ${missingExport.map((d) => String(d.messageText)).join('; ')}`,
+  )
+
+  console.log('diagnostics.test.cjs: OK')
+}
+
+main()

--- a/packages/ryunix-vscode/test/fixtures/diagnostics/asset-import.ryx
+++ b/packages/ryunix-vscode/test/fixtures/diagnostics/asset-import.ryx
@@ -1,0 +1,9 @@
+import logo from '@/resources/logo.svg'
+
+export default function Page() {
+  return (
+    <main>
+      <img src={logo} alt="Logo" />
+    </main>
+  )
+}

--- a/packages/ryunix-vscode/test/fixtures/diagnostics/bad-import.ryx
+++ b/packages/ryunix-vscode/test/fixtures/diagnostics/bad-import.ryx
@@ -1,0 +1,8 @@
+export default function Page() {
+  const value = doesNotExist
+  return (
+    <main>
+      <h1>{value}</h1>
+    </main>
+  )
+}

--- a/packages/ryunix-vscode/test/fixtures/diagnostics/components/ui/Icon.ryx
+++ b/packages/ryunix-vscode/test/fixtures/diagnostics/components/ui/Icon.ryx
@@ -1,0 +1,3 @@
+export default function Icon({ name }) {
+  return <span className="icon">{name}</span>
+}

--- a/packages/ryunix-vscode/test/fixtures/diagnostics/components/ui/Image.ryx
+++ b/packages/ryunix-vscode/test/fixtures/diagnostics/components/ui/Image.ryx
@@ -1,0 +1,3 @@
+export default function Image({ src, alt, className }) {
+  return <img src={src} alt={alt} className={className} />
+}

--- a/packages/ryunix-vscode/test/fixtures/diagnostics/image-jsx.ryx
+++ b/packages/ryunix-vscode/test/fixtures/diagnostics/image-jsx.ryx
@@ -1,0 +1,9 @@
+import Image from '@/components/ui/Image.ryx'
+
+export default function Page() {
+  return (
+    <main>
+      <Image src="/logo.svg" alt="Logo" />
+    </main>
+  )
+}

--- a/packages/ryunix-vscode/test/fixtures/diagnostics/jsconfig.json
+++ b/packages/ryunix-vscode/test/fixtures/diagnostics/jsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react",
+    "jsxFactory": "Ryunix.createElement",
+    "jsxFragmentFactory": "Ryunix.Fragment",
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["**/*.ryx"]
+}

--- a/packages/ryunix-vscode/test/fixtures/diagnostics/resources/logo.svg
+++ b/packages/ryunix-vscode/test/fixtures/diagnostics/resources/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"><rect width="1" height="1"/></svg>

--- a/packages/ryunix-vscode/test/fixtures/diagnostics/ryunix-named-imports.ryx
+++ b/packages/ryunix-vscode/test/fixtures/diagnostics/ryunix-named-imports.ryx
@@ -1,0 +1,14 @@
+import { useRouter, useStore, Link } from '@unsetsoft/ryunixjs'
+
+export default function Page() {
+  const router = useRouter()
+  const [count, setCount] = useStore(0)
+
+  return (
+    <main>
+      <p>{router.location}</p>
+      <p>{count}</p>
+      <Link to="/">Home</Link>
+    </main>
+  )
+}

--- a/packages/ryunix-vscode/test/fixtures/diagnostics/ryx-import-ext.ryx
+++ b/packages/ryunix-vscode/test/fixtures/diagnostics/ryx-import-ext.ryx
@@ -1,0 +1,9 @@
+import Icon from '@/components/ui/Icon.ryx'
+
+export default function Page() {
+  return (
+    <main>
+      <Icon name="home" />
+    </main>
+  )
+}

--- a/packages/ryunix-vscode/test/fixtures/diagnostics/ryx-import-no-ext.ryx
+++ b/packages/ryunix-vscode/test/fixtures/diagnostics/ryx-import-no-ext.ryx
@@ -1,0 +1,9 @@
+import Icon from '@/components/ui/Icon'
+
+export default function Page() {
+  return (
+    <main>
+      <Icon name="home" />
+    </main>
+  )
+}

--- a/packages/ryunix-vscode/test/fixtures/diagnostics/syntax-error.ryx
+++ b/packages/ryunix-vscode/test/fixtures/diagnostics/syntax-error.ryx
@@ -1,0 +1,1 @@
+export default function Page() { return ( <div>{ unclosed

--- a/packages/ryunix-vscode/test/tsconfig-paths.test.cjs
+++ b/packages/ryunix-vscode/test/tsconfig-paths.test.cjs
@@ -1,0 +1,75 @@
+/**
+ * Tests for ryunix.config.js → compilerOptions.paths mapping.
+ */
+const path = require('path')
+const fs = require('fs')
+const os = require('os')
+
+const {
+  pathsFromRyunixConfig,
+  mergeCompilerPaths,
+  hasPathPrefix,
+} = require('../server/out/ryunix-config-paths')
+const { loadCompilerOptions } = require('../server/out/ts-program')
+const { resolveRyunixTypesEntry } = require('../server/out/ryunix-types-resolve')
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function withTempRyunixConfig(content, fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ryx-paths-'))
+  fs.writeFileSync(path.join(dir, 'ryunix.config.js'), content)
+  try {
+    fn(dir)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+function main() {
+  withTempRyunixConfig(
+    `module.exports = { webpack: { resolve: { alias: { '@': './src' } } } }`,
+    (dir) => {
+      const paths = pathsFromRyunixConfig(dir)
+      assert(paths['@/*'], 'expected @/* path from ryunix.config.js')
+      assert(
+        paths['@/*'][0].includes('src'),
+        '@/* should map to src directory',
+      )
+    },
+  )
+
+  assert(
+    hasPathPrefix({ '@/*': ['./src/*'] }, '@'),
+    'hasPathPrefix should detect @',
+  )
+  assert(
+    !hasPathPrefix({}, '@'),
+    'hasPathPrefix should be false for empty paths',
+  )
+
+  const merged = mergeCompilerPaths(
+    { '@unsetsoft/ryunixjs': ['node_modules/@unsetsoft/ryunixjs'] },
+    { '@/*': ['./src/*'] },
+  )
+  assert(merged['@/*'], 'mergeCompilerPaths should add alias paths')
+
+  const fixtureRoot = path.join(
+    __dirname,
+    'fixtures/resolve-root/with-ryunix-config',
+  )
+  const opts = loadCompilerOptions(fixtureRoot, { preferTsconfig: false })
+  assert(opts.paths, 'loadCompilerOptions should return paths object')
+
+  const monorepoRoot = path.join(__dirname, '..', '..', '..')
+  const coreTypes = resolveRyunixTypesEntry(monorepoRoot)
+  assert(
+    coreTypes && coreTypes.includes('packages/core/types/index.d.ts'),
+    'resolveRyunixTypesEntry should find monorepo core types',
+  )
+
+  console.log('tsconfig-paths.test.cjs: OK')
+}
+
+main()


### PR DESCRIPTION
## Summary
- add diagnostics fixtures for `.ryx` files, including syntax, import, and asset cases
- add server-side helpers for diagnostics filters and config/path resolution
- add tests for diagnostics and tsconfig path handling

## Test plan
- [x] cherry-pick applied cleanly on top of `origin/canary`
- [x] verify branch diff only touches `packages/ryunix-vscode`
- [x] run package-level tests once manifest scripts are available in this branch baseline