### PR TITLE
feat(cra): enable checkJs and template path aliases

### DIFF
--- a/packages/cra/templates/ryunix-base/jsconfig.json
+++ b/packages/cra/templates/ryunix-base/jsconfig.json
@@ -12,7 +12,9 @@
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      "@unsetsoft/ryunixjs": ["node_modules/@unsetsoft/ryunixjs/types/index.d.ts"],
+      "@unsetsoft/ryunixjs": [
+        "node_modules/@unsetsoft/ryunixjs/types/index.d.ts"
+      ],
       "@/*": ["./*"]
     }
   },

--- a/packages/cra/templates/ryunix-base/jsconfig.json
+++ b/packages/cra/templates/ryunix-base/jsconfig.json
@@ -7,12 +7,13 @@
     "jsxFactory": "Ryunix.createElement",
     "jsxFragmentFactory": "Ryunix.Fragment",
     "allowJs": true,
-    "checkJs": false,
+    "checkJs": true,
     "skipLibCheck": true,
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      "@unsetsoft/ryunixjs": ["node_modules/@unsetsoft/ryunixjs"]
+      "@unsetsoft/ryunixjs": ["node_modules/@unsetsoft/ryunixjs/types/index.d.ts"],
+      "@/*": ["./*"]
     }
   },
   "include": ["**/*.ryx", "**/*.js", "app/**/*"],


### PR DESCRIPTION
## Summary
- add `jsconfig.json` for `packages/cra/templates/ryunix-base`
- default `checkJs` to `true` for generated apps
- add `@/*` alias and point `@unsetsoft/ryunixjs` to published type declarations

## Test plan
- [x] cherry-pick conflict resolved locally on top of `origin/canary`
- [x] verify branch diff only touches CRA template config
- [x] run full monorepo lint/test in CI