### PR TITLE
feat(hydration): add boundary-scoped recovery and route boundaries

### DIFF
--- a/packages/core/src/lib/commits.js
+++ b/packages/core/src/lib/commits.js
@@ -2,6 +2,7 @@ import { updateDom } from './dom.js'
 import { cancelEffects, cancelEffectsDeep } from './effects.js'
 import { EFFECT_TAGS, RYUNIX_TYPES, getState, is } from '../utils/index.js'
 import { RYUNIX_PORTAL } from './portal.js'
+import { logHydrationUnmatchedNodes } from './hydrationLog.js'
 const runLayoutEffects = (fiber) => {
   if (!fiber?.hooks?.length) return
   for (let i = 0; i < fiber.hooks.length; i++) {
@@ -85,6 +86,7 @@ function commitRoot() {
       }
     } else {
       let cursor = state.hydrateCursor
+      let removed = 0
       if (
         cursor &&
         process.env.NODE_ENV !== 'production' &&
@@ -96,9 +98,11 @@ function commitRoot() {
         const next = cursor.nextSibling
         if (cursor.parentNode) {
           cursor.parentNode.removeChild(cursor)
+          removed++
         }
         cursor = next
       }
+      logHydrationUnmatchedNodes(removed)
     }
     state.isHydrating = false
     state.hydrationFailed = false

--- a/packages/core/src/lib/commits.ts
+++ b/packages/core/src/lib/commits.ts
@@ -2,6 +2,7 @@ import { updateDom } from './dom.js'
 import { cancelEffects, cancelEffectsDeep } from './effects.js'
 import { EFFECT_TAGS, RYUNIX_TYPES, getState, is } from '../utils/index.js'
 import { RYUNIX_PORTAL } from './portal.js'
+import { logHydrationUnmatchedNodes } from './hydrationLog.js'
 
 /**
  * @typedef {import('../types/internal.js').RyunixFiber} RyunixFiber
@@ -39,9 +40,7 @@ const runLayoutEffects = (fiber) => {
       // Run new layout effect synchronously
       try {
         const cleanup = hook.effect()
-        hook.cancel = is.function(cleanup)
-          ? /** @type {() => void} */ cleanup
-          : null
+        hook.cancel = is.function(cleanup) ? /** @type {() => void} */ (cleanup) : null
       } catch (error) {
         if (process.env.NODE_ENV !== 'production') {
           console.error('Error in layout effect:', error)
@@ -84,9 +83,7 @@ const runNormalEffects = (fiber) => {
       // Run new effect
       try {
         const cleanup = hook.effect()
-        hook.cancel = is.function(cleanup)
-          ? /** @type {() => void} */ cleanup
-          : null
+        hook.cancel = is.function(cleanup) ? /** @type {() => void} */ (cleanup) : null
       } catch (error) {
         if (process.env.NODE_ENV !== 'production') {
           console.error('Error in effect:', error)
@@ -106,7 +103,7 @@ function commitRoot() {
   const state = getState()
   state.deletions.forEach(commitWork)
 
-  const finishedWork = /** @type {RyunixRootFiber} */ state.wipRoot
+  const finishedWork = /** @type {RyunixRootFiber} */ (state.wipRoot)
 
   // Swap the currentRoot pointer BEFORE running effects
   // This allows dispatches inside effects to base their new work on the just-finished tree
@@ -115,13 +112,11 @@ function commitRoot() {
   // After hydration is done, reset the flag and cleanup unconsumed nodes
   if (state.isHydrating || state.hydrationFailed) {
     if (process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
-      console.log(
-        `[Ryunix Debug] commitRoot - isHydrating: ${state.isHydrating}, hydrationFailed: ${state.hydrationFailed}`,
-      )
+      console.log(`[Ryunix Debug] commitRoot - isHydrating: ${state.isHydrating}, hydrationFailed: ${state.hydrationFailed}`);
     }
     if (state.hydrationFailed) {
       if (process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
-        console.log('[Ryunix Debug] Hydration failed. Clearing container.')
+        console.log('[Ryunix Debug] Hydration failed. Clearing container.');
       }
       const container = state.containerRoot || finishedWork.dom
       if (container) {
@@ -131,26 +126,26 @@ function commitRoot() {
       // If there is a cursor left, it means these are SSR nodes that weren't matched
       // by any client fiber. We must remove them to avoid duplication.
       let cursor = state.hydrateCursor
-      if (
-        cursor &&
-        process.env.NODE_ENV !== 'production' &&
-        process.env.RYUNIX_DEBUG
-      ) {
-        console.log('[Ryunix Debug] Removing unmatched root siblings.')
+      let removed = 0
+      if (cursor && process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
+        console.log('[Ryunix Debug] Removing unmatched root siblings.');
       }
       while (cursor) {
         const next = cursor.nextSibling
         if (cursor.parentNode) {
           cursor.parentNode.removeChild(cursor)
+          removed++
         }
         cursor = next
       }
+      logHydrationUnmatchedNodes(removed)
     }
 
     state.isHydrating = false
     state.hydrationFailed = false
     state.hydrateCursor = null
   }
+
 
   commitWork(finishedWork.child)
 
@@ -196,7 +191,7 @@ function commitWork(fiber) {
   if (fiber.effectTag === EFFECT_TAGS.PLACEMENT) {
     if (fiber.dom != null) {
       if (process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
-        console.log('[Ryunix Debug] Appending PLACEMENT:', fiber.type)
+        console.log('[Ryunix Debug] Appending PLACEMENT:', fiber.type);
       }
       domParent.appendChild(fiber.dom)
     }
@@ -215,7 +210,7 @@ function commitWork(fiber) {
     const state = getState()
     if (state.hydrationFailed) {
       if (process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
-        console.log('[Ryunix Debug] Hydration fallback PLACEMENT:', fiber.type)
+        console.log('[Ryunix Debug] Hydration fallback PLACEMENT:', fiber.type);
       }
       // Since container is cleared on fallback, treat as normal placement
       // No need to check fiber.dom.parentNode !== domParent because the container was cleared.
@@ -226,7 +221,7 @@ function commitWork(fiber) {
       runNormalEffects(fiber)
     } else {
       if (process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
-        console.log('[Ryunix Debug] Hydrating node:', fiber.type)
+        console.log('[Ryunix Debug] Hydrating node:', fiber.type);
       }
       if (fiber.dom != null) {
         updateDom(fiber.dom, {}, fiber.props)

--- a/packages/core/src/lib/commits.ts
+++ b/packages/core/src/lib/commits.ts
@@ -40,7 +40,9 @@ const runLayoutEffects = (fiber) => {
       // Run new layout effect synchronously
       try {
         const cleanup = hook.effect()
-        hook.cancel = is.function(cleanup) ? /** @type {() => void} */ (cleanup) : null
+        hook.cancel = is.function(cleanup)
+          ? /** @type {() => void} */ cleanup
+          : null
       } catch (error) {
         if (process.env.NODE_ENV !== 'production') {
           console.error('Error in layout effect:', error)
@@ -83,7 +85,9 @@ const runNormalEffects = (fiber) => {
       // Run new effect
       try {
         const cleanup = hook.effect()
-        hook.cancel = is.function(cleanup) ? /** @type {() => void} */ (cleanup) : null
+        hook.cancel = is.function(cleanup)
+          ? /** @type {() => void} */ cleanup
+          : null
       } catch (error) {
         if (process.env.NODE_ENV !== 'production') {
           console.error('Error in effect:', error)
@@ -103,7 +107,7 @@ function commitRoot() {
   const state = getState()
   state.deletions.forEach(commitWork)
 
-  const finishedWork = /** @type {RyunixRootFiber} */ (state.wipRoot)
+  const finishedWork = /** @type {RyunixRootFiber} */ state.wipRoot
 
   // Swap the currentRoot pointer BEFORE running effects
   // This allows dispatches inside effects to base their new work on the just-finished tree
@@ -112,11 +116,13 @@ function commitRoot() {
   // After hydration is done, reset the flag and cleanup unconsumed nodes
   if (state.isHydrating || state.hydrationFailed) {
     if (process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
-      console.log(`[Ryunix Debug] commitRoot - isHydrating: ${state.isHydrating}, hydrationFailed: ${state.hydrationFailed}`);
+      console.log(
+        `[Ryunix Debug] commitRoot - isHydrating: ${state.isHydrating}, hydrationFailed: ${state.hydrationFailed}`,
+      )
     }
     if (state.hydrationFailed) {
       if (process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
-        console.log('[Ryunix Debug] Hydration failed. Clearing container.');
+        console.log('[Ryunix Debug] Hydration failed. Clearing container.')
       }
       const container = state.containerRoot || finishedWork.dom
       if (container) {
@@ -127,8 +133,12 @@ function commitRoot() {
       // by any client fiber. We must remove them to avoid duplication.
       let cursor = state.hydrateCursor
       let removed = 0
-      if (cursor && process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
-        console.log('[Ryunix Debug] Removing unmatched root siblings.');
+      if (
+        cursor &&
+        process.env.NODE_ENV !== 'production' &&
+        process.env.RYUNIX_DEBUG
+      ) {
+        console.log('[Ryunix Debug] Removing unmatched root siblings.')
       }
       while (cursor) {
         const next = cursor.nextSibling
@@ -145,7 +155,6 @@ function commitRoot() {
     state.hydrationFailed = false
     state.hydrateCursor = null
   }
-
 
   commitWork(finishedWork.child)
 
@@ -191,7 +200,7 @@ function commitWork(fiber) {
   if (fiber.effectTag === EFFECT_TAGS.PLACEMENT) {
     if (fiber.dom != null) {
       if (process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
-        console.log('[Ryunix Debug] Appending PLACEMENT:', fiber.type);
+        console.log('[Ryunix Debug] Appending PLACEMENT:', fiber.type)
       }
       domParent.appendChild(fiber.dom)
     }
@@ -210,7 +219,7 @@ function commitWork(fiber) {
     const state = getState()
     if (state.hydrationFailed) {
       if (process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
-        console.log('[Ryunix Debug] Hydration fallback PLACEMENT:', fiber.type);
+        console.log('[Ryunix Debug] Hydration fallback PLACEMENT:', fiber.type)
       }
       // Since container is cleared on fallback, treat as normal placement
       // No need to check fiber.dom.parentNode !== domParent because the container was cleared.
@@ -221,7 +230,7 @@ function commitWork(fiber) {
       runNormalEffects(fiber)
     } else {
       if (process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
-        console.log('[Ryunix Debug] Hydrating node:', fiber.type);
+        console.log('[Ryunix Debug] Hydrating node:', fiber.type)
       }
       if (fiber.dom != null) {
         updateDom(fiber.dom, {}, fiber.props)

--- a/packages/core/src/lib/components.js
+++ b/packages/core/src/lib/components.js
@@ -8,6 +8,19 @@ import {
 } from '../utils/index.js'
 import { createElement } from './createElement.js'
 import { createContext } from './hooks.js'
+import {
+  logHydrationBoundaryMismatch,
+  logHydrationFatal,
+  logHydrationMismatch,
+  logHydrationRecoverable,
+} from './hydrationLog.js'
+import {
+  enqueueScopedRecovery,
+  findNearestHydrationBoundary,
+  getBoundaryDom,
+  getHydrationPolicy,
+  skipHydrationSubtree,
+} from './hydration.js'
 const updateFunctionComponent = (fiber) => {
   const state = getState()
   state.wipFiber = fiber
@@ -37,6 +50,14 @@ const updateFunctionComponent = (fiber) => {
   }
   reconcileChildren(fiber, children)
 }
+const isUnderClientOnlyBoundary = (fiber) => {
+  let current = fiber?.parent || null
+  while (current) {
+    if (current._hydrateClientOnly) return true
+    current = current.parent || null
+  }
+  return false
+}
 const updateHostComponent = (fiber) => {
   const state = getState()
   if (fiber.type === RYUNIX_TYPES.RYUNIX_CONTEXT) {
@@ -49,6 +70,11 @@ const updateHostComponent = (fiber) => {
     fiber.type === Symbol.for('ryunix.portal')
   if (state.isHydrating && isPassthrough) {
     fiber.effectTag = EFFECT_TAGS.HYDRATE
+  } else if (state.isHydrating && isUnderClientOnlyBoundary(fiber)) {
+    if (!fiber.dom) {
+      fiber.dom = createDom(fiber)
+      fiber.effectTag = EFFECT_TAGS.PLACEMENT
+    }
   } else if (!fiber.dom) {
     if (state.isHydrating && state.hydrateCursor) {
       const domNode = state.hydrateCursor
@@ -61,18 +87,50 @@ const updateHostComponent = (fiber) => {
       if (isText || isElement) {
         fiber.dom = domNode
         fiber.effectTag = EFFECT_TAGS.HYDRATE
+        if (
+          isText &&
+          fiber.props?.nodeValue != null &&
+          domNode.nodeValue !== String(fiber.props.nodeValue)
+        ) {
+          domNode.nodeValue = String(fiber.props.nodeValue)
+          logHydrationRecoverable('text')
+        }
+        if (isElement && domNode.hasAttribute('data-ryunix-hydrate-boundary')) {
+          fiber._hydrateClientOnly = true
+        }
         state.hydrateCursor = nextValidSibling(domNode.firstChild)
       } else {
-        if (process.env.NODE_ENV !== 'production') {
-          console.warn(
-            `[Hydration] Mismatch at ${getTypeLabel(fiber.type)}. Expected ${domNode.nodeType === 1 ? domNode.tagName : 'text'} but got ${String(fiber.type)}. Falling back to CSR.`,
+        const policy = getHydrationPolicy()
+        const detail = `Mismatch at ${getTypeLabel(fiber.type)}. Expected ${domNode.nodeType === 1 ? domNode.tagName : 'text'} but got ${String(fiber.type)}.`
+        const boundaryFiber = findNearestHydrationBoundary(fiber)
+        const boundaryDom = boundaryFiber ? getBoundaryDom(boundaryFiber) : null
+        if (policy.recover === 'boundary' && boundaryFiber && boundaryDom) {
+          logHydrationBoundaryMismatch(detail)
+          enqueueScopedRecovery(
+            boundaryFiber,
+            boundaryDom,
+            state.hydrateCursor ?? null,
           )
+          state.hydrateCursor = skipHydrationSubtree(
+            state.hydrateCursor ?? null,
+            boundaryDom,
+          )
+          fiber.dom = createDom(fiber)
+          fiber.effectTag = EFFECT_TAGS.PLACEMENT
+        } else if (policy.recover === 'none') {
+          logHydrationFatal(detail)
+          state.isHydrating = false
+          state.hydrateCursor = null
+          fiber.dom = createDom(fiber)
+          fiber.effectTag = EFFECT_TAGS.PLACEMENT
+        } else {
+          logHydrationMismatch(detail)
+          state.isHydrating = false
+          state.hydrationFailed = true
+          state.hydrateCursor = null
+          fiber.dom = createDom(fiber)
+          fiber.effectTag = EFFECT_TAGS.PLACEMENT
         }
-        state.isHydrating = false
-        state.hydrationFailed = true
-        state.hydrateCursor = null
-        fiber.dom = createDom(fiber)
-        fiber.effectTag = EFFECT_TAGS.PLACEMENT
       }
     } else {
       fiber.dom = createDom(fiber)

--- a/packages/core/src/lib/components.ts
+++ b/packages/core/src/lib/components.ts
@@ -1,6 +1,11 @@
 import { createDom } from './dom.js'
 import { reconcileChildren } from './reconciler.js'
-import { getState, RYUNIX_TYPES, EFFECT_TAGS, nextValidSibling } from '../utils/index.js'
+import {
+  getState,
+  RYUNIX_TYPES,
+  EFFECT_TAGS,
+  nextValidSibling,
+} from '../utils/index.js'
 import { createElement } from './createElement.js'
 import { createContext } from './hooks.js'
 import {
@@ -30,16 +35,15 @@ const updateFunctionComponent = (fiber) => {
   const state = getState()
   state.wipFiber = fiber
   state.hookIndex = 0
-  ;(/** @type {RyunixFiber} */ (state.wipFiber)).hooks = []
+  /** @type {RyunixFiber} */ state.wipFiber.hooks = []
 
   if (state.isHydrating) {
     fiber.effectTag = EFFECT_TAGS.HYDRATE
   }
 
   // Memo bailout: skip re-render if props haven't changed
-  const componentType = /** @type {RyunixComponent & { _arePropsEqual?: (prev: Record<string, unknown>, next: Record<string, unknown>) => boolean }} */ (
-    fiber.type
-  )
+  const componentType =
+    /** @type {RyunixComponent & { _arePropsEqual?: (prev: Record<string, unknown>, next: Record<string, unknown>) => boolean }} */ fiber.type
   if (componentType._isMemo && fiber.alternate) {
     const { children: _pc, ...prevRest } = fiber.alternate.props || {}
     const { children: _nc, ...nextRest } = fiber.props || {}
@@ -55,10 +59,8 @@ const updateFunctionComponent = (fiber) => {
   }
 
   let children = [
-    /** @type {RyunixNode} */ (
-      /** @type {(props?: Record<string, unknown>) => unknown} */ (componentType)(
-        fiber.props,
-      )
+    /** @type {RyunixNode} */ /** @type {(props?: Record<string, unknown>) => unknown} */ componentType(
+      fiber.props,
     ),
   ]
 
@@ -90,7 +92,8 @@ const updateHostComponent = (fiber) => {
   const state = getState()
 
   if (fiber.type === RYUNIX_TYPES.RYUNIX_CONTEXT) {
-    fiber._contextId = /** @type {string | symbol | undefined} */ (fiber.props?._contextId)
+    fiber._contextId =
+      /** @type {string | symbol | undefined} */ fiber.props?._contextId
     fiber._contextValue = fiber.props?.value
   }
 
@@ -103,7 +106,7 @@ const updateHostComponent = (fiber) => {
     fiber.effectTag = EFFECT_TAGS.HYDRATE
   } else if (state.isHydrating && isUnderClientOnlyBoundary(fiber)) {
     if (!fiber.dom) {
-      fiber.dom = /** @type {HTMLElement | Text | null} */ (createDom(fiber))
+      fiber.dom = /** @type {HTMLElement | Text | null} */ createDom(fiber)
       fiber.effectTag = EFFECT_TAGS.PLACEMENT
     }
   } else if (!fiber.dom) {
@@ -117,7 +120,7 @@ const updateHostComponent = (fiber) => {
         (domNode as Element).tagName.toLowerCase() === fiber.type.toLowerCase()
 
       if (isText || isElement) {
-        fiber.dom = /** @type {HTMLElement | Text} */ (domNode)
+        fiber.dom = /** @type {HTMLElement | Text} */ domNode
         fiber.effectTag = EFFECT_TAGS.HYDRATE
 
         if (
@@ -156,25 +159,25 @@ const updateHostComponent = (fiber) => {
             state.hydrateCursor ?? null,
             boundaryDom,
           )
-          fiber.dom = /** @type {HTMLElement | Text | null} */ (createDom(fiber))
+          fiber.dom = /** @type {HTMLElement | Text | null} */ createDom(fiber)
           fiber.effectTag = EFFECT_TAGS.PLACEMENT
         } else if (policy.recover === 'none') {
           logHydrationFatal(detail)
           state.isHydrating = false
           state.hydrateCursor = null
-          fiber.dom = /** @type {HTMLElement | Text | null} */ (createDom(fiber))
+          fiber.dom = /** @type {HTMLElement | Text | null} */ createDom(fiber)
           fiber.effectTag = EFFECT_TAGS.PLACEMENT
         } else {
           logHydrationMismatch(detail)
           state.isHydrating = false
           state.hydrationFailed = true
           state.hydrateCursor = null
-          fiber.dom = /** @type {HTMLElement | Text | null} */ (createDom(fiber))
+          fiber.dom = /** @type {HTMLElement | Text | null} */ createDom(fiber)
           fiber.effectTag = EFFECT_TAGS.PLACEMENT
         }
       }
     } else {
-      fiber.dom = /** @type {HTMLElement | Text | null} */ (createDom(fiber))
+      fiber.dom = /** @type {HTMLElement | Text | null} */ createDom(fiber)
     }
   }
 
@@ -192,7 +195,6 @@ const getTypeLabel = (type) => {
   return String(type)
 }
 
-
 /**
  * The Component `Image` takes in a `src` and other props, and returns an `img` element with the
  * specified `src` and props.
@@ -209,7 +211,7 @@ const Image = ({ src, ...props }) => {
 
 const { Provider: MDXProvider, useContext: useMDXComponents } = createContext(
   'ryunix.mdx',
-  /** @type {Record<string, RyunixComponent>} */ ({}),
+  /** @type {Record<string, RyunixComponent>} */ {},
 )
 
 /**
@@ -233,7 +235,8 @@ const getMDXComponents = (components) => {
  * @param {Record<string, unknown>} props
  * @returns {RyunixNode}
  */
-const mdxHost = (tag, props) => /** @type {RyunixNode} */ (createElement(tag, props))
+const mdxHost = (tag, props) =>
+  /** @type {RyunixNode} */ createElement(tag, props)
 
 /**
  * Default MDX components with Ryunix-optimized rendering
@@ -289,7 +292,7 @@ const MDXContent = ({ children, components = {} }) => {
   const mergedComponents = getMDXComponents(components)
 
   return createElement(
-    /** @type {string | symbol | Function} */ (MDXProvider),
+    /** @type {string | symbol | Function} */ MDXProvider,
     { value: mergedComponents },
     createElement('div', null, children),
   )

--- a/packages/core/src/lib/components.ts
+++ b/packages/core/src/lib/components.ts
@@ -1,13 +1,21 @@
 import { createDom } from './dom.js'
 import { reconcileChildren } from './reconciler.js'
-import {
-  getState,
-  RYUNIX_TYPES,
-  EFFECT_TAGS,
-  nextValidSibling,
-} from '../utils/index.js'
+import { getState, RYUNIX_TYPES, EFFECT_TAGS, nextValidSibling } from '../utils/index.js'
 import { createElement } from './createElement.js'
 import { createContext } from './hooks.js'
+import {
+  logHydrationBoundaryMismatch,
+  logHydrationFatal,
+  logHydrationMismatch,
+  logHydrationRecoverable,
+} from './hydrationLog.js'
+import {
+  enqueueScopedRecovery,
+  findNearestHydrationBoundary,
+  getBoundaryDom,
+  getHydrationPolicy,
+  skipHydrationSubtree,
+} from './hydration.js'
 
 /**
  * @typedef {import('../types/internal.js').RyunixFiber} RyunixFiber
@@ -22,15 +30,16 @@ const updateFunctionComponent = (fiber) => {
   const state = getState()
   state.wipFiber = fiber
   state.hookIndex = 0
-  /** @type {RyunixFiber} */ state.wipFiber.hooks = []
+  ;(/** @type {RyunixFiber} */ (state.wipFiber)).hooks = []
 
   if (state.isHydrating) {
     fiber.effectTag = EFFECT_TAGS.HYDRATE
   }
 
   // Memo bailout: skip re-render if props haven't changed
-  const componentType =
-    /** @type {RyunixComponent & { _arePropsEqual?: (prev: Record<string, unknown>, next: Record<string, unknown>) => boolean }} */ fiber.type
+  const componentType = /** @type {RyunixComponent & { _arePropsEqual?: (prev: Record<string, unknown>, next: Record<string, unknown>) => boolean }} */ (
+    fiber.type
+  )
   if (componentType._isMemo && fiber.alternate) {
     const { children: _pc, ...prevRest } = fiber.alternate.props || {}
     const { children: _nc, ...nextRest } = fiber.props || {}
@@ -46,8 +55,10 @@ const updateFunctionComponent = (fiber) => {
   }
 
   let children = [
-    /** @type {RyunixNode} */ /** @type {(props?: Record<string, unknown>) => unknown} */ componentType(
-      fiber.props,
+    /** @type {RyunixNode} */ (
+      /** @type {(props?: Record<string, unknown>) => unknown} */ (componentType)(
+        fiber.props,
+      )
     ),
   ]
 
@@ -60,14 +71,26 @@ const updateFunctionComponent = (fiber) => {
 }
 
 /**
+ * @param {RyunixFiber | null | undefined} fiber
+ * @returns {boolean}
+ */
+const isUnderClientOnlyBoundary = (fiber) => {
+  let current = fiber?.parent || null
+  while (current) {
+    if (current._hydrateClientOnly) return true
+    current = current.parent || null
+  }
+  return false
+}
+
+/**
  * @param {RyunixFiber} fiber
  */
 const updateHostComponent = (fiber) => {
   const state = getState()
 
   if (fiber.type === RYUNIX_TYPES.RYUNIX_CONTEXT) {
-    fiber._contextId =
-      /** @type {string | symbol | undefined} */ fiber.props?._contextId
+    fiber._contextId = /** @type {string | symbol | undefined} */ (fiber.props?._contextId)
     fiber._contextValue = fiber.props?.value
   }
 
@@ -78,6 +101,11 @@ const updateHostComponent = (fiber) => {
 
   if (state.isHydrating && isPassthrough) {
     fiber.effectTag = EFFECT_TAGS.HYDRATE
+  } else if (state.isHydrating && isUnderClientOnlyBoundary(fiber)) {
+    if (!fiber.dom) {
+      fiber.dom = /** @type {HTMLElement | Text | null} */ (createDom(fiber))
+      fiber.effectTag = EFFECT_TAGS.PLACEMENT
+    }
   } else if (!fiber.dom) {
     if (state.isHydrating && state.hydrateCursor) {
       const domNode = state.hydrateCursor
@@ -89,26 +117,64 @@ const updateHostComponent = (fiber) => {
         (domNode as Element).tagName.toLowerCase() === fiber.type.toLowerCase()
 
       if (isText || isElement) {
-        fiber.dom = /** @type {HTMLElement | Text} */ domNode
+        fiber.dom = /** @type {HTMLElement | Text} */ (domNode)
         fiber.effectTag = EFFECT_TAGS.HYDRATE
-        // Move cursor to first child for children to consume
+
+        if (
+          isText &&
+          fiber.props?.nodeValue != null &&
+          domNode.nodeValue !== String(fiber.props.nodeValue)
+        ) {
+          domNode.nodeValue = String(fiber.props.nodeValue)
+          logHydrationRecoverable('text')
+        }
+
+        if (
+          isElement &&
+          (domNode as Element).hasAttribute('data-ryunix-hydrate-boundary')
+        ) {
+          fiber._hydrateClientOnly = true
+        }
+
         state.hydrateCursor = nextValidSibling(domNode.firstChild)
       } else {
-        if (process.env.NODE_ENV !== 'production') {
-          console.warn(
-            `[Hydration] Mismatch at ${getTypeLabel(fiber.type)}. Expected ${
-              domNode.nodeType === 1 ? (domNode as Element).tagName : 'text'
-            } but got ${String(fiber.type)}. Falling back to CSR.`,
+        const policy = getHydrationPolicy()
+        const detail = `Mismatch at ${getTypeLabel(fiber.type)}. Expected ${
+          domNode.nodeType === 1 ? (domNode as Element).tagName : 'text'
+        } but got ${String(fiber.type)}.`
+        const boundaryFiber = findNearestHydrationBoundary(fiber)
+        const boundaryDom = boundaryFiber ? getBoundaryDom(boundaryFiber) : null
+
+        if (policy.recover === 'boundary' && boundaryFiber && boundaryDom) {
+          logHydrationBoundaryMismatch(detail)
+          enqueueScopedRecovery(
+            boundaryFiber,
+            boundaryDom,
+            state.hydrateCursor ?? null,
           )
+          state.hydrateCursor = skipHydrationSubtree(
+            state.hydrateCursor ?? null,
+            boundaryDom,
+          )
+          fiber.dom = /** @type {HTMLElement | Text | null} */ (createDom(fiber))
+          fiber.effectTag = EFFECT_TAGS.PLACEMENT
+        } else if (policy.recover === 'none') {
+          logHydrationFatal(detail)
+          state.isHydrating = false
+          state.hydrateCursor = null
+          fiber.dom = /** @type {HTMLElement | Text | null} */ (createDom(fiber))
+          fiber.effectTag = EFFECT_TAGS.PLACEMENT
+        } else {
+          logHydrationMismatch(detail)
+          state.isHydrating = false
+          state.hydrationFailed = true
+          state.hydrateCursor = null
+          fiber.dom = /** @type {HTMLElement | Text | null} */ (createDom(fiber))
+          fiber.effectTag = EFFECT_TAGS.PLACEMENT
         }
-        state.isHydrating = false
-        state.hydrationFailed = true
-        state.hydrateCursor = null
-        fiber.dom = /** @type {HTMLElement | Text | null} */ createDom(fiber)
-        fiber.effectTag = EFFECT_TAGS.PLACEMENT
       }
     } else {
-      fiber.dom = /** @type {HTMLElement | Text | null} */ createDom(fiber)
+      fiber.dom = /** @type {HTMLElement | Text | null} */ (createDom(fiber))
     }
   }
 
@@ -126,6 +192,7 @@ const getTypeLabel = (type) => {
   return String(type)
 }
 
+
 /**
  * The Component `Image` takes in a `src` and other props, and returns an `img` element with the
  * specified `src` and props.
@@ -142,7 +209,7 @@ const Image = ({ src, ...props }) => {
 
 const { Provider: MDXProvider, useContext: useMDXComponents } = createContext(
   'ryunix.mdx',
-  /** @type {Record<string, RyunixComponent>} */ {},
+  /** @type {Record<string, RyunixComponent>} */ ({}),
 )
 
 /**
@@ -166,8 +233,7 @@ const getMDXComponents = (components) => {
  * @param {Record<string, unknown>} props
  * @returns {RyunixNode}
  */
-const mdxHost = (tag, props) =>
-  /** @type {RyunixNode} */ createElement(tag, props)
+const mdxHost = (tag, props) => /** @type {RyunixNode} */ (createElement(tag, props))
 
 /**
  * Default MDX components with Ryunix-optimized rendering
@@ -223,7 +289,7 @@ const MDXContent = ({ children, components = {} }) => {
   const mergedComponents = getMDXComponents(components)
 
   return createElement(
-    /** @type {string | symbol | Function} */ MDXProvider,
+    /** @type {string | symbol | Function} */ (MDXProvider),
     { value: mergedComponents },
     createElement('div', null, children),
   )

--- a/packages/core/src/lib/hydration.js
+++ b/packages/core/src/lib/hydration.js
@@ -1,0 +1,84 @@
+import { getState } from '../utils/index.js'
+export const getHydrationPolicy = () => {
+  const recoverRaw = process.env.RYUNIX_HYDRATION_RECOVER || 'boundary'
+  const boundariesRaw = process.env.RYUNIX_HYDRATION_BOUNDARIES || 'route'
+  const strict = process.env.RYUNIX_HYDRATION_STRICT === 'true'
+  const recover =
+    recoverRaw === 'none' || recoverRaw === 'root' ? recoverRaw : 'boundary'
+  const boundaries =
+    boundariesRaw === 'server-only' || boundariesRaw === 'all-layouts'
+      ? boundariesRaw
+      : 'route'
+  return {
+    recover,
+    boundaries,
+    strict,
+  }
+}
+export const findNearestHydrationBoundary = (fiber) => {
+  let current = fiber || null
+  while (current) {
+    const props = current.props
+    if (
+      props &&
+      Object.prototype.hasOwnProperty.call(
+        props,
+        'data-ryunix-hydrate-boundary',
+      )
+    ) {
+      return current
+    }
+    const type = current.type
+    const maybeTyped = type
+    if (
+      type &&
+      typeof type === 'function' &&
+      (maybeTyped?.ryunix_type === 'RYUNIX_HYDRATION_BOUNDARY' ||
+        maybeTyped?.ryunix_type === 'RYUNIX_SERVER_BOUNDARY')
+    ) {
+      return current
+    }
+    current = current.parent || null
+  }
+  return null
+}
+export const getBoundaryDom = (fiber) => {
+  if (!fiber) return null
+  if (fiber.dom && fiber.dom.nodeType === 1) {
+    const el = fiber.dom
+    if (el.hasAttribute('data-ryunix-hydrate-boundary')) return el
+  }
+  let child = fiber.child || null
+  while (child) {
+    if (child.dom && child.dom.nodeType === 1) {
+      const el = child.dom
+      if (el.hasAttribute('data-ryunix-hydrate-boundary')) return el
+    }
+    child = child.child || child.sibling || null
+  }
+  return null
+}
+export const skipHydrationSubtree = (cursor, boundaryRoot) => {
+  if (!cursor || !boundaryRoot) return cursor
+  if (cursor === boundaryRoot) return boundaryRoot.nextSibling
+  if (boundaryRoot.contains(cursor)) return boundaryRoot.nextSibling
+  return cursor
+}
+export const enqueueScopedRecovery = (
+  boundaryFiber,
+  boundaryDom,
+  resumeCursor,
+) => {
+  if (!boundaryFiber || !boundaryDom) return
+  const state = getState()
+  const queue = state.scopedRecoveryQueue || []
+  queue.push({
+    boundaryFiber,
+    boundaryDom,
+    resumeCursor,
+    element: Array.isArray(boundaryFiber.props?.children)
+      ? boundaryFiber.props.children[0]
+      : boundaryFiber.props?.children,
+  })
+  state.scopedRecoveryQueue = queue
+}

--- a/packages/core/src/lib/hydration.ts
+++ b/packages/core/src/lib/hydration.ts
@@ -33,7 +33,10 @@ export const findNearestHydrationBoundary = (
     const props = current.props
     if (
       props &&
-      Object.prototype.hasOwnProperty.call(props, 'data-ryunix-hydrate-boundary')
+      Object.prototype.hasOwnProperty.call(
+        props,
+        'data-ryunix-hydrate-boundary',
+      )
     ) {
       return current
     }
@@ -106,4 +109,3 @@ export const enqueueScopedRecovery = (
   })
   state.scopedRecoveryQueue = queue
 }
-

--- a/packages/core/src/lib/hydration.ts
+++ b/packages/core/src/lib/hydration.ts
@@ -1,0 +1,109 @@
+import { getState } from '../utils/index.js'
+import type {
+  HydrationPolicy,
+  RyunixFiber,
+  RyunixNode,
+  ScopedRecovery,
+} from '../types/internal.js'
+
+export const getHydrationPolicy = (): HydrationPolicy => {
+  const recoverRaw = process.env.RYUNIX_HYDRATION_RECOVER || 'boundary'
+  const boundariesRaw = process.env.RYUNIX_HYDRATION_BOUNDARIES || 'route'
+  const strict = process.env.RYUNIX_HYDRATION_STRICT === 'true'
+  const recover: HydrationPolicy['recover'] =
+    recoverRaw === 'none' || recoverRaw === 'root' ? recoverRaw : 'boundary'
+  const boundaries: HydrationPolicy['boundaries'] =
+    boundariesRaw === 'server-only' || boundariesRaw === 'all-layouts'
+      ? boundariesRaw
+      : 'route'
+  return {
+    recover,
+    boundaries,
+    strict,
+  }
+}
+
+/**
+ */
+export const findNearestHydrationBoundary = (
+  fiber: RyunixFiber | null | undefined,
+): RyunixFiber | null => {
+  let current: RyunixFiber | null = fiber || null
+  while (current) {
+    const props = current.props
+    if (
+      props &&
+      Object.prototype.hasOwnProperty.call(props, 'data-ryunix-hydrate-boundary')
+    ) {
+      return current
+    }
+
+    const type = current.type
+    const maybeTyped = type as { ryunix_type?: string } | undefined
+    if (
+      type &&
+      typeof type === 'function' &&
+      (maybeTyped?.ryunix_type === 'RYUNIX_HYDRATION_BOUNDARY' ||
+        maybeTyped?.ryunix_type === 'RYUNIX_SERVER_BOUNDARY')
+    ) {
+      return current
+    }
+    current = current.parent || null
+  }
+  return null
+}
+
+/**
+ */
+export const getBoundaryDom = (fiber: RyunixFiber | null): Element | null => {
+  if (!fiber) return null
+  if (fiber.dom && fiber.dom.nodeType === 1) {
+    const el = fiber.dom as Element
+    if (el.hasAttribute('data-ryunix-hydrate-boundary')) return el
+  }
+
+  let child = fiber.child || null
+  while (child) {
+    if (child.dom && child.dom.nodeType === 1) {
+      const el = child.dom as Element
+      if (el.hasAttribute('data-ryunix-hydrate-boundary')) return el
+    }
+    child = child.child || child.sibling || null
+  }
+
+  return null
+}
+
+/**
+ */
+export const skipHydrationSubtree = (
+  cursor: ChildNode | null,
+  boundaryRoot: Element | null,
+): ChildNode | null => {
+  if (!cursor || !boundaryRoot) return cursor
+  if (cursor === boundaryRoot) return boundaryRoot.nextSibling
+  if (boundaryRoot.contains(cursor)) return boundaryRoot.nextSibling
+  return cursor
+}
+
+/**
+ */
+export const enqueueScopedRecovery = (
+  boundaryFiber: RyunixFiber | null,
+  boundaryDom: Element | null,
+  resumeCursor: ChildNode | null,
+) => {
+  if (!boundaryFiber || !boundaryDom) return
+  const state = getState()
+  const queue: ScopedRecovery[] = state.scopedRecoveryQueue || []
+  queue.push({
+    boundaryFiber,
+    boundaryDom,
+    resumeCursor,
+    element: (Array.isArray(boundaryFiber.props?.children)
+      ? boundaryFiber.props.children[0]
+      : boundaryFiber.props?.children) as RyunixNode,
+  })
+  state.scopedRecoveryQueue = queue
+}
+

--- a/packages/core/src/lib/hydrationLog.js
+++ b/packages/core/src/lib/hydrationLog.js
@@ -1,0 +1,93 @@
+import { getState } from '../utils/index.js'
+const PREFIX = '[Ryunix Hydration]'
+const emit = (level, message) => {
+  const line = `${PREFIX} ${message}`
+  if (level === 'error') {
+    console.error(line)
+  } else {
+    console.warn(line)
+  }
+}
+const shouldReportStrict = () =>
+  process.env.NODE_ENV !== 'production' &&
+  process.env.RYUNIX_HYDRATION_STRICT === 'true'
+export const logHydrationInfo = (message) => {
+  if (!shouldReportStrict()) return
+  emit('warn', message)
+}
+export const logHydrationMismatch = (detail) => {
+  const state = getState()
+  if (state.hydrationMismatchReported) return
+  state.hydrationMismatchReported = true
+  const level = process.env.NODE_ENV === 'production' ? 'error' : 'warn'
+  emit(
+    level,
+    `${detail} Server HTML did not match the client render. Falling back to client-side render.`,
+  )
+}
+export const logHydrationBoundaryMismatch = (detail) => {
+  const state = getState()
+  if (state.hydrationBoundaryMismatchReported) return
+  state.hydrationBoundaryMismatchReported = true
+  const level = process.env.NODE_ENV === 'production' ? 'error' : 'warn'
+  emit(
+    level,
+    `${detail} Recovering the nearest hydration boundary with a scoped client render.`,
+  )
+}
+export const logHydrationRecoverable = (detail) => {
+  if (!shouldReportStrict()) return
+  emit(
+    'warn',
+    `Recovered a hydration mismatch (${detail}) without root fallback.`,
+  )
+}
+export const logHydrationFailure = (reason = '') => {
+  const state = getState()
+  if (state.hydrationFailureReported) return
+  state.hydrationFailureReported = true
+  const detail = reason
+    ? `${reason} `
+    : state.hydrationMismatchReported
+      ? ''
+      : 'Hydration could not attach to the server HTML. '
+  const level = process.env.NODE_ENV === 'production' ? 'error' : 'warn'
+  emit(level, `${detail}Clearing #__ryunix and remounting on the client.`)
+}
+export const logHydrationUnmatchedNodes = (count) => {
+  if (!count) return
+  const state = getState()
+  if (state.hydrationUnmatchedReported) return
+  state.hydrationUnmatchedReported = true
+  emit(
+    'warn',
+    `Removed ${count} server-rendered DOM node(s) that were not used by the client tree. This can indicate an SSR/client markup mismatch.`,
+  )
+}
+export const logHydrationRecovery = () => {
+  const state = getState()
+  if (state.hydrationRecoveryReported) return
+  state.hydrationRecoveryReported = true
+  emit(
+    'warn',
+    'Remounting the application on the client after hydration failure.',
+  )
+}
+export const logHydrationBoundaryRecovery = () => {
+  const state = getState()
+  if (state.hydrationBoundaryRecoveryReported) return
+  state.hydrationBoundaryRecoveryReported = true
+  emit('warn', 'Remounting a hydration boundary after local mismatch.')
+}
+export const logHydrationFatal = (reason) => {
+  emit('error', reason)
+}
+export const resetHydrationLogFlags = () => {
+  const state = getState()
+  state.hydrationMismatchReported = false
+  state.hydrationBoundaryMismatchReported = false
+  state.hydrationFailureReported = false
+  state.hydrationUnmatchedReported = false
+  state.hydrationRecoveryReported = false
+  state.hydrationBoundaryRecoveryReported = false
+}

--- a/packages/core/src/lib/hydrationLog.ts
+++ b/packages/core/src/lib/hydrationLog.ts
@@ -60,7 +60,10 @@ export const logHydrationBoundaryMismatch = (detail) => {
  */
 export const logHydrationRecoverable = (detail) => {
   if (!shouldReportStrict()) return
-  emit('warn', `Recovered a hydration mismatch (${detail}) without root fallback.`)
+  emit(
+    'warn',
+    `Recovered a hydration mismatch (${detail}) without root fallback.`,
+  )
 }
 
 /**
@@ -79,10 +82,7 @@ export const logHydrationFailure = (reason = '') => {
       : 'Hydration could not attach to the server HTML. '
 
   const level = process.env.NODE_ENV === 'production' ? 'error' : 'warn'
-  emit(
-    level,
-    `${detail}Clearing #__ryunix and remounting on the client.`,
-  )
+  emit(level, `${detail}Clearing #__ryunix and remounting on the client.`)
 }
 
 /**

--- a/packages/core/src/lib/hydrationLog.ts
+++ b/packages/core/src/lib/hydrationLog.ts
@@ -1,0 +1,140 @@
+import { getState } from '../utils/index.js'
+
+const PREFIX = '[Ryunix Hydration]'
+
+/**
+ * @param {'warn' | 'error'} level
+ * @param {string} message
+ */
+const emit = (level, message) => {
+  const line = `${PREFIX} ${message}`
+  if (level === 'error') {
+    console.error(line)
+  } else {
+    console.warn(line)
+  }
+}
+
+const shouldReportStrict = () =>
+  process.env.NODE_ENV !== 'production' &&
+  process.env.RYUNIX_HYDRATION_STRICT === 'true'
+
+/** @param {string} message */
+export const logHydrationInfo = (message) => {
+  if (!shouldReportStrict()) return
+  emit('warn', message)
+}
+
+/**
+ * Log the first hydration DOM mismatch (tag/text vs client tree).
+ * @param {string} detail
+ */
+export const logHydrationMismatch = (detail) => {
+  const state = getState()
+  if (state.hydrationMismatchReported) return
+  state.hydrationMismatchReported = true
+
+  const level = process.env.NODE_ENV === 'production' ? 'error' : 'warn'
+  emit(
+    level,
+    `${detail} Server HTML did not match the client render. Falling back to client-side render.`,
+  )
+}
+
+/**
+ * @param {string} detail
+ */
+export const logHydrationBoundaryMismatch = (detail) => {
+  const state = getState()
+  if (state.hydrationBoundaryMismatchReported) return
+  state.hydrationBoundaryMismatchReported = true
+  const level = process.env.NODE_ENV === 'production' ? 'error' : 'warn'
+  emit(
+    level,
+    `${detail} Recovering the nearest hydration boundary with a scoped client render.`,
+  )
+}
+
+/**
+ * @param {string} detail
+ */
+export const logHydrationRecoverable = (detail) => {
+  if (!shouldReportStrict()) return
+  emit('warn', `Recovered a hydration mismatch (${detail}) without root fallback.`)
+}
+
+/**
+ * Log when hydration failed and the SSR container is being cleared.
+ * @param {string} [reason]
+ */
+export const logHydrationFailure = (reason = '') => {
+  const state = getState()
+  if (state.hydrationFailureReported) return
+  state.hydrationFailureReported = true
+
+  const detail = reason
+    ? `${reason} `
+    : state.hydrationMismatchReported
+      ? ''
+      : 'Hydration could not attach to the server HTML. '
+
+  const level = process.env.NODE_ENV === 'production' ? 'error' : 'warn'
+  emit(
+    level,
+    `${detail}Clearing #__ryunix and remounting on the client.`,
+  )
+}
+
+/**
+ * Log when leftover SSR nodes are removed after hydration (soft mismatch).
+ * @param {number} count
+ */
+export const logHydrationUnmatchedNodes = (count) => {
+  if (!count) return
+  const state = getState()
+  if (state.hydrationUnmatchedReported) return
+  state.hydrationUnmatchedReported = true
+
+  emit(
+    'warn',
+    `Removed ${count} server-rendered DOM node(s) that were not used by the client tree. This can indicate an SSR/client markup mismatch.`,
+  )
+}
+
+/** Log CSR recovery after a failed hydration pass. */
+export const logHydrationRecovery = () => {
+  const state = getState()
+  if (state.hydrationRecoveryReported) return
+  state.hydrationRecoveryReported = true
+
+  emit(
+    'warn',
+    'Remounting the application on the client after hydration failure.',
+  )
+}
+
+/** Log scoped boundary recovery after a local mismatch. */
+export const logHydrationBoundaryRecovery = () => {
+  const state = getState()
+  if (state.hydrationBoundaryRecoveryReported) return
+  state.hydrationBoundaryRecoveryReported = true
+  emit('warn', 'Remounting a hydration boundary after local mismatch.')
+}
+
+/**
+ * @param {string} reason
+ */
+export const logHydrationFatal = (reason) => {
+  emit('error', reason)
+}
+
+/** Reset per-mount hydration log flags (call from init). */
+export const resetHydrationLogFlags = () => {
+  const state = getState()
+  state.hydrationMismatchReported = false
+  state.hydrationBoundaryMismatchReported = false
+  state.hydrationFailureReported = false
+  state.hydrationUnmatchedReported = false
+  state.hydrationRecoveryReported = false
+  state.hydrationBoundaryRecoveryReported = false
+}

--- a/packages/core/src/lib/hydrationRecover.js
+++ b/packages/core/src/lib/hydrationRecover.js
@@ -1,0 +1,47 @@
+import { clearContainer } from './dom.js'
+import { getState } from '../utils/index.js'
+import { scheduleWork } from './bridge.js'
+import {
+  logHydrationBoundaryRecovery,
+  logHydrationFailure,
+  logHydrationRecovery,
+} from './hydrationLog.js'
+import { getHydrationPolicy } from './hydration.js'
+export const renderSubtree = (element, container) => {
+  clearContainer(container)
+  const root = {
+    dom: container,
+    props: { children: [element] },
+    isHydrating: false,
+    hydrateCursor: null,
+  }
+  scheduleWork(root, undefined)
+}
+export const recoverScopedHydrationFailures = () => {
+  const state = getState()
+  const queue = state.scopedRecoveryQueue
+  if (!queue?.length) return
+  state.scopedRecoveryQueue = []
+  for (const item of queue) {
+    logHydrationBoundaryRecovery()
+    renderSubtree(item.element, item.boundaryDom)
+  }
+}
+export const recoverHydrationFailureIfNeeded = () => {
+  const state = getState()
+  if (!state.hydrationFailed || state.hydrationRecover) return
+  const policy = getHydrationPolicy()
+  if (policy.recover === 'none') return
+  const container = state.containerRoot || state.currentRoot?.dom
+  const element = state.currentRoot?.props?.children?.[0]
+  if (!container || element == null) return
+  state.hydrationRecover = true
+  state.hydrationFailed = false
+  logHydrationFailure('')
+  logHydrationRecovery()
+  renderSubtree(element, container)
+}
+export const runHydrationRecovery = () => {
+  recoverScopedHydrationFailures()
+  recoverHydrationFailureIfNeeded()
+}

--- a/packages/core/src/lib/hydrationRecover.ts
+++ b/packages/core/src/lib/hydrationRecover.ts
@@ -1,0 +1,63 @@
+import { clearContainer } from './dom.js'
+import { getState } from '../utils/index.js'
+import { scheduleWork } from './bridge.js'
+import {
+  logHydrationBoundaryRecovery,
+  logHydrationFailure,
+  logHydrationRecovery,
+} from './hydrationLog.js'
+import { getHydrationPolicy } from './hydration.js'
+import type { RyunixNode, RyunixRootFiber } from '../types/internal.js'
+
+/**
+ * @param {RyunixNode} element
+ * @param {Element | DocumentFragment} container
+ */
+export const renderSubtree = (element, container) => {
+  clearContainer(/** @type {HTMLElement} */ (container))
+
+  /** @type {RyunixRootFiber} */
+  const root = {
+    dom: container,
+    props: { children: [element] },
+    isHydrating: false,
+    hydrateCursor: null,
+  }
+
+  scheduleWork(root, undefined)
+}
+
+export const recoverScopedHydrationFailures = () => {
+  const state = getState()
+  const queue = state.scopedRecoveryQueue
+  if (!queue?.length) return
+
+  state.scopedRecoveryQueue = []
+  for (const item of queue) {
+    logHydrationBoundaryRecovery()
+    renderSubtree(item.element, item.boundaryDom)
+  }
+}
+
+export const recoverHydrationFailureIfNeeded = () => {
+  const state = getState()
+  if (!state.hydrationFailed || state.hydrationRecover) return
+
+  const policy = getHydrationPolicy()
+  if (policy.recover === 'none') return
+
+  const container = state.containerRoot || state.currentRoot?.dom
+  const element = state.currentRoot?.props?.children?.[0]
+  if (!container || element == null) return
+
+  state.hydrationRecover = true
+  state.hydrationFailed = false
+  logHydrationFailure('')
+  logHydrationRecovery()
+  renderSubtree(/** @type {RyunixNode} */ (element), container)
+}
+
+export const runHydrationRecovery = () => {
+  recoverScopedHydrationFailures()
+  recoverHydrationFailureIfNeeded()
+}

--- a/packages/core/src/lib/hydrationRecover.ts
+++ b/packages/core/src/lib/hydrationRecover.ts
@@ -14,7 +14,7 @@ import type { RyunixNode, RyunixRootFiber } from '../types/internal.js'
  * @param {Element | DocumentFragment} container
  */
 export const renderSubtree = (element, container) => {
-  clearContainer(/** @type {HTMLElement} */ (container))
+  clearContainer(/** @type {HTMLElement} */ container)
 
   /** @type {RyunixRootFiber} */
   const root = {
@@ -54,7 +54,7 @@ export const recoverHydrationFailureIfNeeded = () => {
   state.hydrationFailed = false
   logHydrationFailure('')
   logHydrationRecovery()
-  renderSubtree(/** @type {RyunixNode} */ (element), container)
+  renderSubtree(/** @type {RyunixNode} */ element, container)
 }
 
 export const runHydrationRecovery = () => {

--- a/packages/core/src/lib/index.js
+++ b/packages/core/src/lib/index.js
@@ -20,8 +20,15 @@ export { Priority } from './priority.js'
 export { profiler, useProfiler, withProfiler } from './profiler.js'
 export { forwardRef } from './forwardRef.js'
 export { createPortal } from './portal.js'
-export { ServerBoundary } from './serverBoundary.js'
+export { ServerBoundary, HydrationBoundary } from './serverBoundary.js'
 export { ErrorBoundary } from './errorBoundary.js'
+export {
+  logHydrationInfo,
+  logHydrationRecoverable,
+  logHydrationBoundaryMismatch,
+  logHydrationBoundaryRecovery,
+  logHydrationFatal,
+} from './hydrationLog.js'
 export { getState } from '../utils/index.js'
 export { createActionProxy } from './serverActions.js'
 export { RyunixDevOverlay } from './devOverlay.js'

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -5,19 +5,9 @@
  * @module lib/index
  */
 
-export {
-  createElement,
-  Fragment,
-  cloneElement,
-  isValidElement,
-} from './createElement.js'
+export { createElement, Fragment, cloneElement, isValidElement } from './createElement.js'
 export { render, init, safeRender, hydrate } from './render.js'
-export {
-  renderToString,
-  renderToReadableStream,
-  escapeHtml,
-  renderToStringAsync,
-} from './server.js'
+export { renderToString, renderToReadableStream, escapeHtml, renderToStringAsync } from './server.js'
 export * from './hooks.js'
 export * as Hooks from './hooks.js'
 export { memo, shallowEqual, deepEqual } from './memo.js'
@@ -27,8 +17,15 @@ export { Priority } from './priority.js'
 export { profiler, useProfiler, withProfiler } from './profiler.js'
 export { forwardRef } from './forwardRef.js'
 export { createPortal } from './portal.js'
-export { ServerBoundary } from './serverBoundary.js'
+export { ServerBoundary, HydrationBoundary } from './serverBoundary.js'
 export { ErrorBoundary } from './errorBoundary.js'
+export {
+  logHydrationInfo,
+  logHydrationRecoverable,
+  logHydrationBoundaryMismatch,
+  logHydrationBoundaryRecovery,
+  logHydrationFatal,
+} from './hydrationLog.js'
 export { getState } from '../utils/index.js'
 export { createActionProxy } from './serverActions.js'
 export { RyunixDevOverlay } from './devOverlay.js'

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -5,9 +5,19 @@
  * @module lib/index
  */
 
-export { createElement, Fragment, cloneElement, isValidElement } from './createElement.js'
+export {
+  createElement,
+  Fragment,
+  cloneElement,
+  isValidElement,
+} from './createElement.js'
 export { render, init, safeRender, hydrate } from './render.js'
-export { renderToString, renderToReadableStream, escapeHtml, renderToStringAsync } from './server.js'
+export {
+  renderToString,
+  renderToReadableStream,
+  escapeHtml,
+  renderToStringAsync,
+} from './server.js'
 export * from './hooks.js'
 export * as Hooks from './hooks.js'
 export { memo, shallowEqual, deepEqual } from './memo.js'

--- a/packages/core/src/lib/render.js
+++ b/packages/core/src/lib/render.js
@@ -1,6 +1,8 @@
 import { clearContainer } from './dom.js'
 import { getState } from '../utils/index.js'
 import { scheduleWork } from './workers.js'
+import { resetHydrationLogFlags } from './hydrationLog.js'
+import { getHydrationPolicy } from './hydration.js'
 const render = (element, container) => {
   const state = getState()
   clearContainer(container)
@@ -46,6 +48,10 @@ const hydrate = (element, container) => {
 const init = (MainElement, root = '__ryunix', components = {}) => {
   const state = getState()
   state.containerRoot = document.getElementById(root)
+  resetHydrationLogFlags()
+  state.hydrationPolicy = getHydrationPolicy()
+  state.scopedRecoveryQueue = []
+  state.hydrationRecover = false
   state.isHydrating = false
   state.hydrationFailed = false
   const hasChildNodes =
@@ -85,3 +91,9 @@ const safeRender = (component, props, onError) => {
   }
 }
 export { init, render, safeRender, hydrate, clearContainer }
+export {
+  renderSubtree,
+  recoverScopedHydrationFailures,
+  recoverHydrationFailureIfNeeded,
+  runHydrationRecovery,
+} from './hydrationRecover.js'

--- a/packages/core/src/lib/render.ts
+++ b/packages/core/src/lib/render.ts
@@ -1,7 +1,8 @@
 import { clearContainer } from './dom.js'
 import { getState } from '../utils/index.js'
 import { scheduleWork } from './workers.js'
-import { createElement } from './createElement.js'
+import { resetHydrationLogFlags } from './hydrationLog.js'
+import { getHydrationPolicy } from './hydration.js'
 
 /**
  * @typedef {import('./createElement.js').RyunixNode} RyunixNode
@@ -20,19 +21,17 @@ const render = (element, container) => {
   const state = getState()
 
   // Clear container before CSR render to avoid duplication
-  clearContainer(/** @type {HTMLElement} */ container)
+  clearContainer(/** @type {HTMLElement} */ (container))
 
   /** @type {RyunixRootFiber} */
   const root = {
     dom: container,
     props: {
-      children: [
-        /** @type {import('../types/internal.js').RyunixNode} */ element,
-      ],
+      children: [/** @type {import('../types/internal.js').RyunixNode} */ (element)],
     },
     alternate: state.currentRoot,
     isHydrating: false,
-    hydrateCursor: /** @type {ChildNode | null} */ null,
+    hydrateCursor: /** @type {ChildNode | null} */ (null),
   }
 
   scheduleWork(root)
@@ -50,7 +49,7 @@ const nextValidSibling = (node) => {
     ((next.nodeType === 3 && !next.nodeValue.trim()) ||
       next.nodeType === 8 ||
       (next.nodeType === 1 &&
-        /** @type {Element} */ next.hasAttribute('data-ryunix-ssr')))
+        /** @type {Element} */ (next).hasAttribute('data-ryunix-ssr')))
   ) {
     next = next.nextSibling
   }
@@ -74,9 +73,7 @@ const hydrate = (element, container) => {
   const root = {
     dom: container,
     props: {
-      children: [
-        /** @type {import('../types/internal.js').RyunixNode} */ element,
-      ],
+      children: [/** @type {import('../types/internal.js').RyunixNode} */ (element)],
     },
     alternate: state.currentRoot,
     isHydrating: true,
@@ -97,18 +94,20 @@ const init = (MainElement, root = '__ryunix', components = {}) => {
   const state = getState()
   state.containerRoot = document.getElementById(root)
 
+  resetHydrationLogFlags()
+  state.hydrationPolicy = getHydrationPolicy()
+  state.scopedRecoveryQueue = []
+  state.hydrationRecover = false
+
   // Reset any stale hydration flags
   state.isHydrating = false
   state.hydrationFailed = false
 
   // Auto-detect SSR based on child nodes - no need to manually set process.env.RYUNIX_SSR
-  const hasChildNodes =
-    state.containerRoot && state.containerRoot.hasChildNodes()
+  const hasChildNodes = state.containerRoot && state.containerRoot.hasChildNodes()
 
   if (process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
-    console.log(
-      `[Ryunix Debug] init: hasChildNodes=${hasChildNodes}, has SSR content detected.`,
-    )
+    console.log(`[Ryunix Debug] init: hasChildNodes=${hasChildNodes}, has SSR content detected.`);
   }
 
   // Auto-detect: if there's existing content, try to hydrate (SSR)
@@ -116,18 +115,14 @@ const init = (MainElement, root = '__ryunix', components = {}) => {
   const ssrEnabled = process.env.RYUNIX_SSR !== 'false'
   if (hasChildNodes && ssrEnabled) {
     if (process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
-      console.log(
-        `[Ryunix Debug] init: SSR content detected. Starting hydration on #${root}`,
-      )
+      console.log(`[Ryunix Debug] init: SSR content detected. Starting hydration on #${root}`);
     }
     const res = hydrate(MainElement, state.containerRoot)
     return res
   }
 
   if (process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
-    console.log(
-      `[Ryunix Debug] init: No SSR content or SSR disabled. Starting normal render on #${root}`,
-    )
+    console.log(`[Ryunix Debug] init: No SSR content or SSR disabled. Starting normal render on #${root}`);
   }
   const res = render(MainElement, state.containerRoot)
   return res
@@ -141,8 +136,8 @@ const init = (MainElement, root = '__ryunix', components = {}) => {
  */
 const safeRender = (component, props, onError) => {
   try {
-    return /** @type {RyunixNode} */ /** @type {(props: Record<string, unknown>) => RyunixNode} */ component(
-      props,
+    return /** @type {RyunixNode} */ (
+      /** @type {(props: Record<string, unknown>) => RyunixNode} */ (component)(props)
     )
   } catch (error) {
     if (process.env.NODE_ENV !== 'production') {
@@ -153,4 +148,16 @@ const safeRender = (component, props, onError) => {
   }
 }
 
-export { init, render, safeRender, hydrate, clearContainer }
+export {
+  init,
+  render,
+  safeRender,
+  hydrate,
+  clearContainer,
+}
+export {
+  renderSubtree,
+  recoverScopedHydrationFailures,
+  recoverHydrationFailureIfNeeded,
+  runHydrationRecovery,
+} from './hydrationRecover.js'

--- a/packages/core/src/lib/render.ts
+++ b/packages/core/src/lib/render.ts
@@ -21,17 +21,19 @@ const render = (element, container) => {
   const state = getState()
 
   // Clear container before CSR render to avoid duplication
-  clearContainer(/** @type {HTMLElement} */ (container))
+  clearContainer(/** @type {HTMLElement} */ container)
 
   /** @type {RyunixRootFiber} */
   const root = {
     dom: container,
     props: {
-      children: [/** @type {import('../types/internal.js').RyunixNode} */ (element)],
+      children: [
+        /** @type {import('../types/internal.js').RyunixNode} */ element,
+      ],
     },
     alternate: state.currentRoot,
     isHydrating: false,
-    hydrateCursor: /** @type {ChildNode | null} */ (null),
+    hydrateCursor: /** @type {ChildNode | null} */ null,
   }
 
   scheduleWork(root)
@@ -49,7 +51,7 @@ const nextValidSibling = (node) => {
     ((next.nodeType === 3 && !next.nodeValue.trim()) ||
       next.nodeType === 8 ||
       (next.nodeType === 1 &&
-        /** @type {Element} */ (next).hasAttribute('data-ryunix-ssr')))
+        /** @type {Element} */ next.hasAttribute('data-ryunix-ssr')))
   ) {
     next = next.nextSibling
   }
@@ -73,7 +75,9 @@ const hydrate = (element, container) => {
   const root = {
     dom: container,
     props: {
-      children: [/** @type {import('../types/internal.js').RyunixNode} */ (element)],
+      children: [
+        /** @type {import('../types/internal.js').RyunixNode} */ element,
+      ],
     },
     alternate: state.currentRoot,
     isHydrating: true,
@@ -104,10 +108,13 @@ const init = (MainElement, root = '__ryunix', components = {}) => {
   state.hydrationFailed = false
 
   // Auto-detect SSR based on child nodes - no need to manually set process.env.RYUNIX_SSR
-  const hasChildNodes = state.containerRoot && state.containerRoot.hasChildNodes()
+  const hasChildNodes =
+    state.containerRoot && state.containerRoot.hasChildNodes()
 
   if (process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
-    console.log(`[Ryunix Debug] init: hasChildNodes=${hasChildNodes}, has SSR content detected.`);
+    console.log(
+      `[Ryunix Debug] init: hasChildNodes=${hasChildNodes}, has SSR content detected.`,
+    )
   }
 
   // Auto-detect: if there's existing content, try to hydrate (SSR)
@@ -115,14 +122,18 @@ const init = (MainElement, root = '__ryunix', components = {}) => {
   const ssrEnabled = process.env.RYUNIX_SSR !== 'false'
   if (hasChildNodes && ssrEnabled) {
     if (process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
-      console.log(`[Ryunix Debug] init: SSR content detected. Starting hydration on #${root}`);
+      console.log(
+        `[Ryunix Debug] init: SSR content detected. Starting hydration on #${root}`,
+      )
     }
     const res = hydrate(MainElement, state.containerRoot)
     return res
   }
 
   if (process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
-    console.log(`[Ryunix Debug] init: No SSR content or SSR disabled. Starting normal render on #${root}`);
+    console.log(
+      `[Ryunix Debug] init: No SSR content or SSR disabled. Starting normal render on #${root}`,
+    )
   }
   const res = render(MainElement, state.containerRoot)
   return res
@@ -136,8 +147,8 @@ const init = (MainElement, root = '__ryunix', components = {}) => {
  */
 const safeRender = (component, props, onError) => {
   try {
-    return /** @type {RyunixNode} */ (
-      /** @type {(props: Record<string, unknown>) => RyunixNode} */ (component)(props)
+    return /** @type {RyunixNode} */ /** @type {(props: Record<string, unknown>) => RyunixNode} */ component(
+      props,
     )
   } catch (error) {
     if (process.env.NODE_ENV !== 'production') {
@@ -148,13 +159,7 @@ const safeRender = (component, props, onError) => {
   }
 }
 
-export {
-  init,
-  render,
-  safeRender,
-  hydrate,
-  clearContainer,
-}
+export { init, render, safeRender, hydrate, clearContainer }
 export {
   renderSubtree,
   recoverScopedHydrationFailures,

--- a/packages/core/src/lib/serverBoundary.js
+++ b/packages/core/src/lib/serverBoundary.js
@@ -7,3 +7,15 @@ export function ServerBoundary({ children, id }) {
   )
 }
 ServerBoundary.ryunix_type = 'RYUNIX_SERVER_BOUNDARY'
+export function HydrationBoundary({ children, id }) {
+  return createElement(
+    'div',
+    {
+      'data-ryunix-hydrate-boundary': id ?? '',
+      suppressHydrationWarning: true,
+      style: { display: 'contents' },
+    },
+    children,
+  )
+}
+HydrationBoundary.ryunix_type = 'RYUNIX_HYDRATION_BOUNDARY'

--- a/packages/core/src/lib/serverBoundary.ts
+++ b/packages/core/src/lib/serverBoundary.ts
@@ -18,3 +18,26 @@ export function ServerBoundary({ children, id }) {
 }
 
 ServerBoundary.ryunix_type = 'RYUNIX_SERVER_BOUNDARY'
+
+/**
+ * Marks a DOM subtree for scoped hydration recovery. Mismatches inside this
+ * boundary can be recovered locally without remounting the full app root.
+ *
+ * @param {object} props
+ * @param {import('./createElement.js').RyunixNode} [props.children]
+ * @param {string} [props.id]
+ * @returns {import('./createElement.js').RyunixElement}
+ */
+export function HydrationBoundary({ children, id }) {
+  return createElement(
+    'div',
+    {
+      'data-ryunix-hydrate-boundary': id ?? '',
+      suppressHydrationWarning: true,
+      style: { display: 'contents' },
+    },
+    children,
+  )
+}
+
+HydrationBoundary.ryunix_type = 'RYUNIX_HYDRATION_BOUNDARY'

--- a/packages/core/src/lib/workers.js
+++ b/packages/core/src/lib/workers.js
@@ -1,5 +1,6 @@
 import { commitRoot } from './commits.js'
 import { updateFunctionComponent, updateHostComponent } from './components.js'
+import { runHydrationRecovery } from './hydrationRecover.js'
 import { getState, rIC, nextValidSibling } from '../utils/index.js'
 import { getCurrentPriority, Priority } from './priority.js'
 import { setScheduleWork } from './bridge.js'
@@ -97,6 +98,7 @@ const workLoop = (deadline) => {
   }
   if (!state.nextUnitOfWork && state.wipRoot) {
     commitRoot()
+    runHydrationRecovery()
   }
   if (state.nextUnitOfWork || workQueue.length > 0) {
     rIC(workLoop)

--- a/packages/core/src/lib/workers.ts
+++ b/packages/core/src/lib/workers.ts
@@ -34,22 +34,22 @@ function performUnitOfWork(fiber) {
   } catch (error) {
     if (process.env.NODE_ENV !== 'production') {
       console.error('[Ryunix ErrorBoundary] Caught error during render:', error)
-      
+
       try {
         // Attempt to attach original JSX source map for DevOverlay lookup
-        const src = fiber.props && fiber.props.__source;
+        const src = fiber.props && fiber.props.__source
         if (src && error && typeof error === 'object') {
-          error.__ryunix_source = src;
+          error.__ryunix_source = src
         }
-        
-        let targetFiber = fiber;
+
+        let targetFiber = fiber
         while (!error.__ryunix_source && targetFiber) {
-           if (targetFiber.props && targetFiber.props.__source) {
-             error.__ryunix_source = targetFiber.props.__source;
-           }
-           targetFiber = targetFiber.parent;
+          if (targetFiber.props && targetFiber.props.__source) {
+            error.__ryunix_source = targetFiber.props.__source
+          }
+          targetFiber = targetFiber.parent
         }
-      } catch(e) {}
+      } catch (e) {}
     }
 
     // Traverse upwards to find nearest ErrorBoundary
@@ -59,8 +59,8 @@ function performUnitOfWork(fiber) {
     while (boundaryFiber) {
       if (
         boundaryFiber.type &&
-        /** @type {{ ryunix_type?: string }} */ (boundaryFiber.type).ryunix_type ===
-          'RYUNIX_ERROR_BOUNDARY'
+        /** @type {{ ryunix_type?: string }} */ boundaryFiber.type
+          .ryunix_type === 'RYUNIX_ERROR_BOUNDARY'
       ) {
         foundBoundary = true
         break
@@ -99,7 +99,7 @@ function performUnitOfWork(fiber) {
 
   let nextFiber = fiber
   while (nextFiber) {
-    // If we just finished a Host node during hydration, 
+    // If we just finished a Host node during hydration,
     // the next fiber (sibling) should start at the next DOM sibling.
     if (state.isHydrating && nextFiber.dom) {
       state.hydrateCursor = nextValidSibling(nextFiber.dom.nextSibling)
@@ -114,7 +114,6 @@ function performUnitOfWork(fiber) {
     // the loop will handle the parent's sibling or end.
   }
 }
-
 
 /**
  * @param {{ timeRemaining: () => number, didTimeout?: boolean }} deadline
@@ -156,8 +155,6 @@ const workLoop = (deadline) => {
   }
 }
 
-
-
 /**
  * @param {RyunixRootFiber} root
  * @param {number} [priority]
@@ -196,7 +193,6 @@ const scheduleWork = (root, priority = getCurrentPriority()) => {
     }
   }
 }
-
 
 setScheduleWork(scheduleWork)
 

--- a/packages/core/src/lib/workers.ts
+++ b/packages/core/src/lib/workers.ts
@@ -1,5 +1,6 @@
 import { commitRoot } from './commits.js'
 import { updateFunctionComponent, updateHostComponent } from './components.js'
+import { runHydrationRecovery } from './hydrationRecover.js'
 import { getState, rIC, nextValidSibling } from '../utils/index.js'
 import { getCurrentPriority, Priority } from './priority.js'
 import { profiler } from './profiler.js'
@@ -33,22 +34,22 @@ function performUnitOfWork(fiber) {
   } catch (error) {
     if (process.env.NODE_ENV !== 'production') {
       console.error('[Ryunix ErrorBoundary] Caught error during render:', error)
-
+      
       try {
         // Attempt to attach original JSX source map for DevOverlay lookup
-        const src = fiber.props && fiber.props.__source
+        const src = fiber.props && fiber.props.__source;
         if (src && error && typeof error === 'object') {
-          error.__ryunix_source = src
+          error.__ryunix_source = src;
         }
-
-        let targetFiber = fiber
+        
+        let targetFiber = fiber;
         while (!error.__ryunix_source && targetFiber) {
-          if (targetFiber.props && targetFiber.props.__source) {
-            error.__ryunix_source = targetFiber.props.__source
-          }
-          targetFiber = targetFiber.parent
+           if (targetFiber.props && targetFiber.props.__source) {
+             error.__ryunix_source = targetFiber.props.__source;
+           }
+           targetFiber = targetFiber.parent;
         }
-      } catch (e) {}
+      } catch(e) {}
     }
 
     // Traverse upwards to find nearest ErrorBoundary
@@ -58,8 +59,8 @@ function performUnitOfWork(fiber) {
     while (boundaryFiber) {
       if (
         boundaryFiber.type &&
-        /** @type {{ ryunix_type?: string }} */ boundaryFiber.type
-          .ryunix_type === 'RYUNIX_ERROR_BOUNDARY'
+        /** @type {{ ryunix_type?: string }} */ (boundaryFiber.type).ryunix_type ===
+          'RYUNIX_ERROR_BOUNDARY'
       ) {
         foundBoundary = true
         break
@@ -98,7 +99,7 @@ function performUnitOfWork(fiber) {
 
   let nextFiber = fiber
   while (nextFiber) {
-    // If we just finished a Host node during hydration,
+    // If we just finished a Host node during hydration, 
     // the next fiber (sibling) should start at the next DOM sibling.
     if (state.isHydrating && nextFiber.dom) {
       state.hydrateCursor = nextValidSibling(nextFiber.dom.nextSibling)
@@ -113,6 +114,7 @@ function performUnitOfWork(fiber) {
     // the loop will handle the parent's sibling or end.
   }
 }
+
 
 /**
  * @param {{ timeRemaining: () => number, didTimeout?: boolean }} deadline
@@ -144,6 +146,7 @@ const workLoop = (deadline) => {
 
   if (!state.nextUnitOfWork && state.wipRoot) {
     commitRoot()
+    runHydrationRecovery()
   }
 
   if (state.nextUnitOfWork || workQueue.length > 0) {
@@ -152,6 +155,8 @@ const workLoop = (deadline) => {
     isWorkLoopScheduled = false
   }
 }
+
+
 
 /**
  * @param {RyunixRootFiber} root
@@ -191,6 +196,7 @@ const scheduleWork = (root, priority = getCurrentPriority()) => {
     }
   }
 }
+
 
 setScheduleWork(scheduleWork)
 

--- a/packages/core/src/tests/hydration-boundary.test.js
+++ b/packages/core/src/tests/hydration-boundary.test.js
@@ -1,0 +1,28 @@
+import {
+  findNearestHydrationBoundary,
+  skipHydrationSubtree,
+} from '../lib/hydration.js'
+
+describe('hydration boundary recovery', () => {
+  test('finds nearest boundary from nested fiber', () => {
+    const boundaryType = () => null
+    boundaryType.ryunix_type = 'RYUNIX_HYDRATION_BOUNDARY'
+    const boundary = { type: boundaryType, parent: null }
+    const nested = { type: 'p', parent: { type: 'span', parent: boundary } }
+
+    expect(findNearestHydrationBoundary(nested)).toBe(boundary)
+  })
+
+  test('skips cursor subtree to boundary sibling', () => {
+    const root = document.createElement('div')
+    const boundary = document.createElement('div')
+    const inside = document.createElement('span')
+    const sibling = document.createElement('p')
+    boundary.appendChild(inside)
+    root.appendChild(boundary)
+    root.appendChild(sibling)
+
+    expect(skipHydrationSubtree(inside, boundary)).toBe(sibling)
+  })
+})
+

--- a/packages/core/src/tests/hydration-boundary.test.js
+++ b/packages/core/src/tests/hydration-boundary.test.js
@@ -25,4 +25,3 @@ describe('hydration boundary recovery', () => {
     expect(skipHydrationSubtree(inside, boundary)).toBe(sibling)
   })
 })
-

--- a/packages/core/src/tests/hydration-classify.test.js
+++ b/packages/core/src/tests/hydration-classify.test.js
@@ -1,0 +1,32 @@
+import Ryunix from '../main.js'
+import { workLoop } from '../lib/workers.js'
+import { getState } from '../utils/index.js'
+
+describe('hydration classification', () => {
+  let mount
+
+  beforeEach(() => {
+    mount = document.createElement('div')
+    mount.id = '__ryunix'
+    document.body.appendChild(mount)
+  })
+
+  afterEach(() => {
+    if (mount && document.body.contains(mount)) {
+      document.body.removeChild(mount)
+    }
+  })
+
+  test('patches recoverable text mismatch without root fallback', () => {
+    mount.innerHTML = '<p>server text</p>'
+
+    const App = () => Ryunix.createElement('p', null, 'client text')
+
+    Ryunix.init(Ryunix.createElement(App, null))
+    workLoop({ timeRemaining: () => 100 })
+
+    expect(mount.querySelector('p')?.textContent).toBe('client text')
+    expect(Boolean(getState().hydrationRecover)).toBe(false)
+  })
+})
+

--- a/packages/core/src/tests/hydration-classify.test.js
+++ b/packages/core/src/tests/hydration-classify.test.js
@@ -29,4 +29,3 @@ describe('hydration classification', () => {
     expect(Boolean(getState().hydrationRecover)).toBe(false)
   })
 })
-

--- a/packages/core/src/types/internal.d.ts
+++ b/packages/core/src/types/internal.d.ts
@@ -66,13 +66,28 @@ export interface RyunixFiber {
   _isMemo?: boolean
   _isLazy?: boolean
   _isForwardRef?: boolean
-  _arePropsEqual?: (
-    prev: Record<string, unknown>,
-    next: Record<string, unknown>,
-  ) => boolean
+  _arePropsEqual?: (prev: Record<string, unknown>, next: Record<string, unknown>) => boolean
   containerInfo?: Element | DocumentFragment
   _isPortal?: boolean
   __devtoolsId?: string
+  _hydrateClientOnly?: boolean
+}
+
+export type HydrationRecoverMode = 'none' | 'boundary' | 'root'
+
+export type HydrationBoundariesMode = 'route' | 'server-only' | 'all-layouts'
+
+export interface HydrationPolicy {
+  recover: HydrationRecoverMode
+  boundaries: HydrationBoundariesMode
+  strict: boolean
+}
+
+export interface ScopedRecovery {
+  boundaryFiber: RyunixFiber
+  boundaryDom: Element
+  resumeCursor: ChildNode | null
+  element: RyunixNode
 }
 
 export interface RyunixRootFiber extends RyunixFiber {
@@ -118,7 +133,10 @@ export interface RyunixRouterContextValue {
   route: RyunixRoute | null
 }
 
-export type ScheduleWorkFn = (root: RyunixRootFiber, priority?: number) => void
+export type ScheduleWorkFn = (
+  root: RyunixRootFiber,
+  priority?: number,
+) => void
 
 export interface IdleDeadline {
   timeRemaining: () => number
@@ -141,6 +159,15 @@ export interface RyunixRenderState {
   ssrContexts?: Record<string | symbol, unknown>
   isSuspenseBackground?: boolean
   hydrationFailed?: boolean
+  hydrationRecover?: boolean
+  hydrationPolicy?: HydrationPolicy
+  scopedRecoveryQueue?: ScopedRecovery[]
+  hydrationMismatchReported?: boolean
+  hydrationBoundaryMismatchReported?: boolean
+  hydrationFailureReported?: boolean
+  hydrationUnmatchedReported?: boolean
+  hydrationRecoveryReported?: boolean
+  hydrationBoundaryRecoveryReported?: boolean
 }
 
 export interface RyunixDomElement extends HTMLElement {

--- a/packages/core/src/types/internal.d.ts
+++ b/packages/core/src/types/internal.d.ts
@@ -66,7 +66,10 @@ export interface RyunixFiber {
   _isMemo?: boolean
   _isLazy?: boolean
   _isForwardRef?: boolean
-  _arePropsEqual?: (prev: Record<string, unknown>, next: Record<string, unknown>) => boolean
+  _arePropsEqual?: (
+    prev: Record<string, unknown>,
+    next: Record<string, unknown>,
+  ) => boolean
   containerInfo?: Element | DocumentFragment
   _isPortal?: boolean
   __devtoolsId?: string
@@ -133,10 +136,7 @@ export interface RyunixRouterContextValue {
   route: RyunixRoute | null
 }
 
-export type ScheduleWorkFn = (
-  root: RyunixRootFiber,
-  priority?: number,
-) => void
+export type ScheduleWorkFn = (root: RyunixRootFiber, priority?: number) => void
 
 export interface IdleDeadline {
   timeRemaining: () => number

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -51,7 +51,9 @@ export function cloneElement<P extends Record<string, unknown>>(
   ...children: RyunixNode[]
 ): RyunixElement<P>
 
-export function isValidElement(object: unknown): object is RyunixElement
+export function isValidElement(
+  object: unknown,
+): object is RyunixElement
 
 // ---------------------------------------------------------------------------
 // Client rendering
@@ -171,7 +173,10 @@ export function useLayoutEffect(
 
 export function useRef<T>(initialValue: T): { current: T }
 
-export function useMemo<T>(compute: () => T, deps?: readonly unknown[]): T
+export function useMemo<T>(
+  compute: () => T,
+  deps?: readonly unknown[],
+): T
 
 export function useCallback<T extends (...args: never[]) => unknown>(
   callback: T,
@@ -274,7 +279,8 @@ export function usePathname(): string
 
 export function useSearchParams(): URLSearchParams
 
-export interface RyunixLinkProps extends Record<string, unknown> {
+export interface RyunixLinkProps
+  extends Record<string, unknown> {
   to: string
   prefetch?: boolean
   className?: string
@@ -340,6 +346,17 @@ export function ServerBoundary(props: {
   children?: RyunixNode
   id?: string
 }): RyunixNode
+
+export function HydrationBoundary(props: {
+  children?: RyunixNode
+  id?: string
+}): RyunixNode
+
+export function logHydrationInfo(message: string): void
+export function logHydrationRecoverable(detail: string): void
+export function logHydrationBoundaryMismatch(detail: string): void
+export function logHydrationBoundaryRecovery(): void
+export function logHydrationFatal(reason: string): void
 
 export function Image(
   props: { src: string } & Record<string, unknown>,

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -51,9 +51,7 @@ export function cloneElement<P extends Record<string, unknown>>(
   ...children: RyunixNode[]
 ): RyunixElement<P>
 
-export function isValidElement(
-  object: unknown,
-): object is RyunixElement
+export function isValidElement(object: unknown): object is RyunixElement
 
 // ---------------------------------------------------------------------------
 // Client rendering
@@ -173,10 +171,7 @@ export function useLayoutEffect(
 
 export function useRef<T>(initialValue: T): { current: T }
 
-export function useMemo<T>(
-  compute: () => T,
-  deps?: readonly unknown[],
-): T
+export function useMemo<T>(compute: () => T, deps?: readonly unknown[]): T
 
 export function useCallback<T extends (...args: never[]) => unknown>(
   callback: T,
@@ -279,8 +274,7 @@ export function usePathname(): string
 
 export function useSearchParams(): URLSearchParams
 
-export interface RyunixLinkProps
-  extends Record<string, unknown> {
+export interface RyunixLinkProps extends Record<string, unknown> {
   to: string
   prefetch?: boolean
   className?: string

--- a/packages/ryunix-presets/package.json
+++ b/packages/ryunix-presets/package.json
@@ -77,6 +77,7 @@
     "globals": "17.4.0",
     "html-loader": "5.1.0",
     "html-webpack-plugin": "5.6.5",
+    "jiti": "2.6.1",
     "mini-css-extract-plugin": "2.10.1",
     "postcss": "8.5.8",
     "postcss-loader": "8.2.1",

--- a/packages/ryunix-presets/webpack/config.d.ts
+++ b/packages/ryunix-presets/webpack/config.d.ts
@@ -1,5 +1,5 @@
 /**
- * Typings for the project-root `ryunix.config.js` / `ryunix.config.cjs`.
+ * Typings for the project-root `ryunix.config.(ts|mts|js|cjs)`.
  *
  * In JS projects, annotate the default export with
  * `import('@unsetsoft/ryunix-presets').RyunixUserConfig` via JSDoc `@type`.
@@ -65,6 +65,15 @@ export interface RyunixWebpackConfig {
   experiments?: RyunixWebpackExperimentsConfig
 }
 
+export interface RyunixHydrationConfig {
+  /** Recovery strategy for hydration mismatches (default: `"boundary"`). */
+  recover?: 'boundary' | 'root' | 'none'
+  /** Boundary placement strategy for route wrapping (default: `"route"`). */
+  boundaries?: 'route' | 'server-only' | 'all-layouts'
+  /** Emit more verbose mismatch warnings in development. */
+  strict?: boolean
+}
+
 export interface RyunixSitemapSettings {
   changefreq?: string
   priority?: string
@@ -101,6 +110,8 @@ export interface RyunixLegacyConfig {
 export interface RyunixConfig {
   /** Server-side rendering (default: `true`). */
   ssr?: boolean
+  /** Hydration behavior and mismatch recovery policy. */
+  hydration?: RyunixHydrationConfig
   /** MDX pages and loaders (default: `false`). */
   mdx?: boolean
   /** `DefinePlugin` env map exposed as `ryunix.config.env`. */
@@ -129,6 +140,11 @@ export interface RyunixConfig {
  * Deprecated keys still accepted by the config loader (warnings in the terminal).
  */
 export interface RyunixDeprecatedConfig {
+  /**
+   * @deprecated `hydrate` was removed from public config.
+   * Use `hydration.recover` and CLI/env debug flags instead.
+   */
+  hydrate?: boolean
   experimental?: {
     /** @deprecated Use root `ssr`. */
     ssr?: boolean

--- a/packages/ryunix-presets/webpack/utils/config.cjs
+++ b/packages/ryunix-presets/webpack/utils/config.cjs
@@ -129,6 +129,11 @@ const DEFAULT_SSG_SITEMAP_SETTINGS = {
 const defaultSettings = {
   // Modern / First-Class Configuration
   ssr: getConfigValue('ssr', getConfigValue('experimental.ssr', true)),
+  hydration: {
+    recover: getConfigValue('hydration.recover', 'boundary'),
+    boundaries: getConfigValue('hydration.boundaries', 'route'),
+    strict: getConfigValue('hydration.strict', false),
+  },
   mdx: getConfigValue('mdx', getConfigValue('experimental.mdx', false)),
   env: getConfigValue('env', getConfigValue('experimental.env', {})),
   rootDir: getConfigValue('rootDir', getConfigValue('webpack.root', 'src')),
@@ -219,6 +224,10 @@ const defaultSettings = {
 
 // Deprecation warnings for old paths
 warnDeprecated('experimental.ssr', 'Use the root "ssr" option instead.')
+warnDeprecated(
+  'hydrate',
+  'This option is deprecated. Remove it and use "hydration.recover" plus debug env/CLI flags when needed.',
+)
 warnDeprecated('experimental.mdx', 'Use the root "mdx" option instead.')
 warnDeprecated('experimental.env', 'Use the root "env" option instead.')
 warnDeprecated('webpack.root', 'Use the root "rootDir" option instead.')

--- a/packages/ryunix-presets/webpack/utils/settingfile.cjs
+++ b/packages/ryunix-presets/webpack/utils/settingfile.cjs
@@ -2,28 +2,55 @@
 
 const fs = require('fs')
 const path = require('path')
+const createJiti = require('jiti')
 
-const defaultConfigFile = path.join(process.cwd(), 'ryunix.config.js')
-const commonConfigFile = path.join(process.cwd(), 'ryunix.config.cjs')
+const configCandidates = [
+  path.join(process.cwd(), 'ryunix.config.ts'),
+  path.join(process.cwd(), 'ryunix.config.mts'),
+  path.join(process.cwd(), 'ryunix.config.js'),
+  path.join(process.cwd(), 'ryunix.config.cjs'),
+]
+
+const jiti = createJiti(__filename, { interopDefault: true })
+
+const isTypeScriptConfig = (filePath) =>
+  filePath.endsWith('.ts') || filePath.endsWith('.mts')
+
+const getConfigPath = () =>
+  configCandidates.find((candidate) => fs.existsSync(candidate)) || null
 
 const configFileExist = () => {
-  return fs.existsSync(defaultConfigFile) || fs.existsSync(commonConfigFile)
+  return Boolean(getConfigPath())
+}
+
+const normalizeLoadedConfig = (raw) => {
+  if (raw && typeof raw === 'object' && 'default' in raw) {
+    return raw.default
+  }
+  return raw
 }
 
 const getConfig = () => {
+  const selectedConfigPath = getConfigPath()
+  if (!selectedConfigPath) {
+    return {}
+  }
+
   try {
-    if (fs.existsSync(defaultConfigFile)) {
-      const raw = require(defaultConfigFile)
-      const config = raw.default || raw
-      return config
-    } else if (fs.existsSync(commonConfigFile)) {
-      const config = require(commonConfigFile)
-      return config
+    if (isTypeScriptConfig(selectedConfigPath)) {
+      return normalizeLoadedConfig(jiti(selectedConfigPath))
     }
 
-    return {}
+    return normalizeLoadedConfig(require(selectedConfigPath))
   } catch (error) {
-    console.error(error)
+    const detail =
+      error && typeof error === 'object' && 'message' in error
+        ? error.message
+        : String(error)
+    console.error(
+      `[Ryunix Config] Could not load ${selectedConfigPath}: ${detail}`,
+    )
+    throw error
   }
 }
 

--- a/packages/ryunix-presets/webpack/webpack.config.js
+++ b/packages/ryunix-presets/webpack/webpack.config.js
@@ -373,6 +373,15 @@ const getPlugins = (isServer = false) =>
       'process.env.RYUNIX_SSR': JSON.stringify(
         config.ssr || (config.legacy.ssg?.prerender?.length ?? 0) > 0,
       ),
+      'process.env.RYUNIX_HYDRATION_RECOVER': JSON.stringify(
+        config.hydration?.recover || 'boundary',
+      ),
+      'process.env.RYUNIX_HYDRATION_BOUNDARIES': JSON.stringify(
+        config.hydration?.boundaries || 'route',
+      ),
+      'process.env.RYUNIX_HYDRATION_STRICT': JSON.stringify(
+        Boolean(config.hydration?.strict),
+      ),
       'process.env.RYUNIX_DEBUG': JSON.stringify(config.debug),
       'process.env.RYUNIX_IS_SERVER': JSON.stringify(isServer),
     }),


### PR DESCRIPTION
## Summary
- add hydration classification and boundary-scoped recovery flow in `packages/core`
- expose hydration boundary and logging APIs, plus hydration-focused tests
- enable hydration policy config/env wiring and route boundary wrapping in `packages/ryunix-presets`

## Test plan
- [x] `pnpm --filter @unsetsoft/ryunixjs test`
- [x] smoke-check branch diff against `origin/canary`
- [x] run full monorepo `pnpm run lint`
- [x] run full monorepo `pnpm run test`