### PR TITLE
fix(hydration): route-level HydrationBoundary and recovery hardening

### DIFF
--- a/packages/core/src/lib/commits.js
+++ b/packages/core/src/lib/commits.js
@@ -77,13 +77,8 @@ function commitRoot() {
       )
     }
     if (state.hydrationFailed) {
-      if (process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
-        console.log('[Ryunix Debug] Hydration failed. Clearing container.')
-      }
-      const container = state.containerRoot || finishedWork.dom
-      if (container) {
-        container.textContent = ''
-      }
+      // Do not wipe the container here. recoverHydrationFailureIfNeeded → renderSubtree
+      // clears and re-renders; clearing early leaves a blank page if recovery fails.
     } else {
       let cursor = state.hydrateCursor
       let removed = 0

--- a/packages/core/src/lib/commits.ts
+++ b/packages/core/src/lib/commits.ts
@@ -121,13 +121,7 @@ function commitRoot() {
       )
     }
     if (state.hydrationFailed) {
-      if (process.env.NODE_ENV !== 'production' && process.env.RYUNIX_DEBUG) {
-        console.log('[Ryunix Debug] Hydration failed. Clearing container.')
-      }
-      const container = state.containerRoot || finishedWork.dom
-      if (container) {
-        container.textContent = ''
-      }
+      // Defer clearing to recoverHydrationFailureIfNeeded → renderSubtree.
     } else {
       // If there is a cursor left, it means these are SSR nodes that weren't matched
       // by any client fiber. We must remove them to avoid duplication.

--- a/packages/core/src/lib/hydration.js
+++ b/packages/core/src/lib/hydration.js
@@ -1,7 +1,6 @@
 import { getState } from '../utils/index.js'
 export const getHydrationPolicy = () => {
-  const env =
-    typeof process !== 'undefined' && process.env ? process.env : {}
+  const env = typeof process !== 'undefined' && process.env ? process.env : {}
   const recoverRaw = env.RYUNIX_HYDRATION_RECOVER || 'boundary'
   const boundariesRaw = env.RYUNIX_HYDRATION_BOUNDARIES || 'route'
   const strict = env.RYUNIX_HYDRATION_STRICT === 'true'

--- a/packages/core/src/lib/hydration.js
+++ b/packages/core/src/lib/hydration.js
@@ -1,8 +1,10 @@
 import { getState } from '../utils/index.js'
 export const getHydrationPolicy = () => {
-  const recoverRaw = process.env.RYUNIX_HYDRATION_RECOVER || 'boundary'
-  const boundariesRaw = process.env.RYUNIX_HYDRATION_BOUNDARIES || 'route'
-  const strict = process.env.RYUNIX_HYDRATION_STRICT === 'true'
+  const env =
+    typeof process !== 'undefined' && process.env ? process.env : {}
+  const recoverRaw = env.RYUNIX_HYDRATION_RECOVER || 'boundary'
+  const boundariesRaw = env.RYUNIX_HYDRATION_BOUNDARIES || 'route'
+  const strict = env.RYUNIX_HYDRATION_STRICT === 'true'
   const recover =
     recoverRaw === 'none' || recoverRaw === 'root' ? recoverRaw : 'boundary'
   const boundaries =

--- a/packages/core/src/lib/hydration.ts
+++ b/packages/core/src/lib/hydration.ts
@@ -7,8 +7,7 @@ import type {
 } from '../types/internal.js'
 
 export const getHydrationPolicy = (): HydrationPolicy => {
-  const env =
-    typeof process !== 'undefined' && process.env ? process.env : {}
+  const env = typeof process !== 'undefined' && process.env ? process.env : {}
   const recoverRaw = env.RYUNIX_HYDRATION_RECOVER || 'boundary'
   const boundariesRaw = env.RYUNIX_HYDRATION_BOUNDARIES || 'route'
   const strict = env.RYUNIX_HYDRATION_STRICT === 'true'

--- a/packages/core/src/lib/hydration.ts
+++ b/packages/core/src/lib/hydration.ts
@@ -7,9 +7,11 @@ import type {
 } from '../types/internal.js'
 
 export const getHydrationPolicy = (): HydrationPolicy => {
-  const recoverRaw = process.env.RYUNIX_HYDRATION_RECOVER || 'boundary'
-  const boundariesRaw = process.env.RYUNIX_HYDRATION_BOUNDARIES || 'route'
-  const strict = process.env.RYUNIX_HYDRATION_STRICT === 'true'
+  const env =
+    typeof process !== 'undefined' && process.env ? process.env : {}
+  const recoverRaw = env.RYUNIX_HYDRATION_RECOVER || 'boundary'
+  const boundariesRaw = env.RYUNIX_HYDRATION_BOUNDARIES || 'route'
+  const strict = env.RYUNIX_HYDRATION_STRICT === 'true'
   const recover: HydrationPolicy['recover'] =
     recoverRaw === 'none' || recoverRaw === 'root' ? recoverRaw : 'boundary'
   const boundaries: HydrationPolicy['boundaries'] =

--- a/packages/ryunix-presets/package.json
+++ b/packages/ryunix-presets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unsetsoft/ryunix-presets",
   "description": "Package with presets for different development environments.",
-  "version": "1.0.26-canary.38",
+  "version": "1.0.26-canary.40",
   "author": "Neyunse",
   "type": "module",
   "repository": {

--- a/packages/ryunix-presets/webpack/utils/appRouterPlugin.js
+++ b/packages/ryunix-presets/webpack/utils/appRouterPlugin.js
@@ -188,7 +188,7 @@ class AppRouterPlugin {
   }
   generateRouterFile(routeNode, outputPath) {
     const generate = (isServerBuild) => {
-      let importStatements = `import Ryunix, { RouterProvider, Children, useMetadata, useEffect, useStore, ServerBoundary, RyunixDevOverlay } from '@unsetsoft/ryunixjs';\n`
+      let importStatements = `import Ryunix, { RouterProvider, Children, useMetadata, useEffect, useStore, ServerBoundary, HydrationBoundary, RyunixDevOverlay } from '@unsetsoft/ryunixjs';\n`
       let componentIdCounter = 0
       const getNextId = () => componentIdCounter++
       const flattenedRoutes = []
@@ -272,7 +272,7 @@ class AppRouterPlugin {
             flattenedRoutes.push(`
     {
       path: '${node.path}',
-      component: (props) => <RouteWrapper layouts={${layoutsArrayStr}} index={${errorPropStr}} loading={${loadingConfigStr}} error={${errorConfigStr}} props={props} />
+      component: (props) => <RouteWrapper routePath="${node.path}" layouts={${layoutsArrayStr}} index={${errorPropStr}} loading={${loadingConfigStr}} error={${errorConfigStr}} props={props} />
     }`)
             if (isServerBuild) {
               ssgRoutes.push({ path: node.path, meta: {} })
@@ -289,7 +289,7 @@ class AppRouterPlugin {
         flattenedRoutes.push(`
     {
       path: '*',
-      NotFound: (props) => <RouteWrapper layouts={${layoutsArrayStr}} index={{ default: getOptExport(${errorsId}, 'NotFound') || getOptExport(${errorsId}, 'default'), isAsync: false, Metatags: getOptExport(${errorsId}, 'Metatags') || getOptExport(${errorsId}, 'frontmatter') || {} }} props={props} />
+      NotFound: (props) => <RouteWrapper routePath="*" layouts={${layoutsArrayStr}} index={{ default: getOptExport(${errorsId}, 'NotFound') || getOptExport(${errorsId}, 'default'), isAsync: false, Metatags: getOptExport(${errorsId}, 'Metatags') || getOptExport(${errorsId}, 'frontmatter') || {} }} props={props} />
     }`)
       }
       return {
@@ -366,6 +366,16 @@ const SyncComponentRenderer = ({ Component, componentProps, ErrorFallback }) => 
   }
 };
 
+const wrapRouteHydrationBoundary = (element, routePath) => {
+  const mode = process.env.RYUNIX_HYDRATION_BOUNDARIES || 'route';
+  if (!element || mode === 'server-only') return element;
+  if (mode === 'route' || mode === 'all-layouts') {
+    const id = routePath || 'route';
+    return <HydrationBoundary id={id}>{element}</HydrationBoundary>;
+  }
+  return element;
+};
+
 const RouteWrapper = (props) => {
   const isServer = typeof process !== 'undefined' && String(process.env.RYUNIX_IS_SERVER) === 'true';
   if (isServer) {
@@ -374,7 +384,7 @@ const RouteWrapper = (props) => {
   return RouteWrapperClient(props);
 };
 
-const RouteWrapperServer = async ({ layouts, index, props, loading, error }) => {
+const RouteWrapperServer = async ({ routePath, layouts, index, props, loading, error }) => {
   let combinedMeta = {};
   if (layouts) {
     for (const l of layouts) {
@@ -398,10 +408,10 @@ const RouteWrapperServer = async ({ layouts, index, props, loading, error }) => 
   }
   useMetadata(combinedMeta);
 
-  return <RouteWrapperRender layouts={layouts} index={index} props={props} loading={loading} error={error} />;
+  return <RouteWrapperRender routePath={routePath} layouts={layouts} index={index} props={props} loading={loading} error={error} />;
 };
 
-const RouteWrapperClient = ({ layouts, index, props, loading, error }) => {
+const RouteWrapperClient = ({ routePath, layouts, index, props, loading, error }) => {
   const getStaticMeta = () => {
     let meta = {};
     if (layouts) {
@@ -442,10 +452,10 @@ const RouteWrapperClient = ({ layouts, index, props, loading, error }) => {
     runMetadata();
   }, [JSON.stringify(props.params), JSON.stringify(props.query), props.location]);
 
-  return <RouteWrapperRender layouts={layouts} index={index} props={props} loading={loading} error={error} />;
+  return <RouteWrapperRender routePath={routePath} layouts={layouts} index={index} props={props} loading={loading} error={error} />;
 };
 
-const RouteWrapperRender = ({ layouts, index, props, loading, error }) => {
+const RouteWrapperRender = ({ routePath, layouts, index, props, loading, error }) => {
 
   let content = null;
   const isServerRender = typeof process !== 'undefined' && String(process.env.RYUNIX_IS_SERVER) === 'true';
@@ -517,7 +527,7 @@ const RouteWrapperRender = ({ layouts, index, props, loading, error }) => {
     }
   }
 
-  return content;
+  return wrapRouteHydrationBoundary(content, routePath);
 };
 
 const routes = [${flattenedRoutes.join(',\n')}];

--- a/packages/ryunix-presets/webpack/utils/appRouterPlugin.ts
+++ b/packages/ryunix-presets/webpack/utils/appRouterPlugin.ts
@@ -226,7 +226,7 @@ class AppRouterPlugin {
 
   generateRouterFile(routeNode, outputPath) {
     const generate = (isServerBuild) => {
-      let importStatements = `import Ryunix, { RouterProvider, Children, useMetadata, useEffect, useStore, ServerBoundary, RyunixDevOverlay } from '@unsetsoft/ryunixjs';\n`
+      let importStatements = `import Ryunix, { RouterProvider, Children, useMetadata, useEffect, useStore, ServerBoundary, HydrationBoundary, RyunixDevOverlay } from '@unsetsoft/ryunixjs';\n`
       let componentIdCounter = 0
       const getNextId = () => componentIdCounter++
       const flattenedRoutes = []
@@ -324,7 +324,7 @@ class AppRouterPlugin {
             flattenedRoutes.push(`
     {
       path: '${node.path}',
-      component: (props) => <RouteWrapper layouts={${layoutsArrayStr}} index={${errorPropStr}} loading={${loadingConfigStr}} error={${errorConfigStr}} props={props} />
+      component: (props) => <RouteWrapper routePath="${node.path}" layouts={${layoutsArrayStr}} index={${errorPropStr}} loading={${loadingConfigStr}} error={${errorConfigStr}} props={props} />
     }`)
 
             if (isServerBuild) {
@@ -345,7 +345,7 @@ class AppRouterPlugin {
         flattenedRoutes.push(`
     {
       path: '*',
-      NotFound: (props) => <RouteWrapper layouts={${layoutsArrayStr}} index={{ default: getOptExport(${errorsId}, 'NotFound') || getOptExport(${errorsId}, 'default'), isAsync: false, Metatags: getOptExport(${errorsId}, 'Metatags') || getOptExport(${errorsId}, 'frontmatter') || {} }} props={props} />
+      NotFound: (props) => <RouteWrapper routePath="*" layouts={${layoutsArrayStr}} index={{ default: getOptExport(${errorsId}, 'NotFound') || getOptExport(${errorsId}, 'default'), isAsync: false, Metatags: getOptExport(${errorsId}, 'Metatags') || getOptExport(${errorsId}, 'frontmatter') || {} }} props={props} />
     }`)
       }
 
@@ -432,6 +432,16 @@ const SyncComponentRenderer = ({ Component, componentProps, ErrorFallback }) => 
   }
 };
 
+const wrapRouteHydrationBoundary = (element, routePath) => {
+  const mode = process.env.RYUNIX_HYDRATION_BOUNDARIES || 'route';
+  if (!element || mode === 'server-only') return element;
+  if (mode === 'route' || mode === 'all-layouts') {
+    const id = routePath || 'route';
+    return <HydrationBoundary id={id}>{element}</HydrationBoundary>;
+  }
+  return element;
+};
+
 const RouteWrapper = (props) => {
   const isServer = typeof process !== 'undefined' && String(process.env.RYUNIX_IS_SERVER) === 'true';
   if (isServer) {
@@ -440,7 +450,7 @@ const RouteWrapper = (props) => {
   return RouteWrapperClient(props);
 };
 
-const RouteWrapperServer = async ({ layouts, index, props, loading, error }) => {
+const RouteWrapperServer = async ({ routePath, layouts, index, props, loading, error }) => {
   let combinedMeta = {};
   if (layouts) {
     for (const l of layouts) {
@@ -464,10 +474,10 @@ const RouteWrapperServer = async ({ layouts, index, props, loading, error }) => 
   }
   useMetadata(combinedMeta);
 
-  return <RouteWrapperRender layouts={layouts} index={index} props={props} loading={loading} error={error} />;
+  return <RouteWrapperRender routePath={routePath} layouts={layouts} index={index} props={props} loading={loading} error={error} />;
 };
 
-const RouteWrapperClient = ({ layouts, index, props, loading, error }) => {
+const RouteWrapperClient = ({ routePath, layouts, index, props, loading, error }) => {
   const getStaticMeta = () => {
     let meta = {};
     if (layouts) {
@@ -508,10 +518,10 @@ const RouteWrapperClient = ({ layouts, index, props, loading, error }) => {
     runMetadata();
   }, [JSON.stringify(props.params), JSON.stringify(props.query), props.location]);
 
-  return <RouteWrapperRender layouts={layouts} index={index} props={props} loading={loading} error={error} />;
+  return <RouteWrapperRender routePath={routePath} layouts={layouts} index={index} props={props} loading={loading} error={error} />;
 };
 
-const RouteWrapperRender = ({ layouts, index, props, loading, error }) => {
+const RouteWrapperRender = ({ routePath, layouts, index, props, loading, error }) => {
 
   let content = null;
   const isServerRender = typeof process !== 'undefined' && String(process.env.RYUNIX_IS_SERVER) === 'true';
@@ -583,10 +593,8 @@ const RouteWrapperRender = ({ layouts, index, props, loading, error }) => {
     }
   }
 
-  return content;
+  return wrapRouteHydrationBoundary(content, routePath);
 };
-
-const routes = [${flattenedRoutes.join(',\n')}];
 
 export default function AppRouter() {
   const isDev = process.env.NODE_ENV !== 'production';

--- a/packages/ryunix-presets/webpack/webpack.config.js
+++ b/packages/ryunix-presets/webpack/webpack.config.js
@@ -370,20 +370,24 @@ const getPlugins = (isServer = false) =>
       }),
     new webpack.DefinePlugin({
       'ryunix.config.env': JSON.stringify(config.env),
+      'process.env.NODE_ENV': JSON.stringify(
+        process.env.NODE_ENV ||
+          (config.webpack.production ? 'production' : 'development'),
+      ),
       'process.env.RYUNIX_SSR': JSON.stringify(
         config.ssr || (config.legacy.ssg?.prerender?.length ?? 0) > 0,
       ),
-      'process.env.RYUNIX_HYDRATION_RECOVER': JSON.stringify(
-        config.hydration?.recover || 'boundary',
-      ),
-      'process.env.RYUNIX_HYDRATION_BOUNDARIES': JSON.stringify(
-        config.hydration?.boundaries || 'route',
-      ),
-      'process.env.RYUNIX_HYDRATION_STRICT': JSON.stringify(
-        Boolean(config.hydration?.strict),
-      ),
       'process.env.RYUNIX_DEBUG': JSON.stringify(config.debug),
       'process.env.RYUNIX_IS_SERVER': JSON.stringify(isServer),
+      'process.env.RYUNIX_HYDRATION_RECOVER': JSON.stringify(
+        config.hydration?.recover ?? 'boundary',
+      ),
+      'process.env.RYUNIX_HYDRATION_BOUNDARIES': JSON.stringify(
+        config.hydration?.boundaries ?? 'route',
+      ),
+      'process.env.RYUNIX_HYDRATION_STRICT': JSON.stringify(
+        config.hydration?.strict ?? false,
+      ),
     }),
     // Only inject HTML for the client build
     !isServer &&

--- a/packages/ryunix-presets/webpack/webpack.config.ts
+++ b/packages/ryunix-presets/webpack/webpack.config.ts
@@ -385,11 +385,24 @@ const getPlugins = (isServer = false) =>
       }),
     new webpack.DefinePlugin({
       'ryunix.config.env': JSON.stringify(config.env),
+      'process.env.NODE_ENV': JSON.stringify(
+        process.env.NODE_ENV ||
+          (config.webpack.production ? 'production' : 'development'),
+      ),
       'process.env.RYUNIX_SSR': JSON.stringify(
         config.ssr || (config.legacy.ssg?.prerender?.length ?? 0) > 0,
       ),
       'process.env.RYUNIX_DEBUG': JSON.stringify(config.debug),
       'process.env.RYUNIX_IS_SERVER': JSON.stringify(isServer),
+      'process.env.RYUNIX_HYDRATION_RECOVER': JSON.stringify(
+        config.hydration?.recover ?? 'boundary',
+      ),
+      'process.env.RYUNIX_HYDRATION_BOUNDARIES': JSON.stringify(
+        config.hydration?.boundaries ?? 'route',
+      ),
+      'process.env.RYUNIX_HYDRATION_STRICT': JSON.stringify(
+        config.hydration?.strict ?? false,
+      ),
     }),
     // Only inject HTML for the client build
     !isServer &&


### PR DESCRIPTION
## Summary
- Wrap each generated route in `HydrationBoundary` when `hydration.boundaries` is `route` or `all-layouts` (completes #547 intent in `appRouterPlugin`).
- Define `process.env.NODE_ENV` and hydration env flags consistently in webpack `DefinePlugin`.
- Stop clearing `#__ryunix` in `commitRoot` before scoped recovery runs (avoids blank page on failed recovery).
- Harden `getHydrationPolicy()` when `process.env` is unavailable.

## Test plan
- [x] `pnpm --filter @unsetsoft/ryunixjs test` passes (hydration boundary tests)
- [x] `pnpm --filter @unsetsoft/ryunix-presets run build` emits updated app router with `HydrationBoundary`
- [x] `test/webpack1` or `ryunix-doc`: production build + browser hydration without root fallback
- [x] Publish `@unsetsoft/ryunix-presets@1.0.26-canary.40` after merge for docs site bump