### PR TITLE
!IMPORTANT: fix(presets): restore routes array in generated AppRouter template

### DIFF
--- a/packages/ryunix-presets/webpack/utils/appRouterPlugin.ts
+++ b/packages/ryunix-presets/webpack/utils/appRouterPlugin.ts
@@ -696,6 +696,8 @@ const RouteWrapperRender = ({ routePath, layouts, index, props, loading, error }
   return wrapRouteHydrationBoundary(content, routePath);
 };
 
+const routes = [${flattenedRoutes.join(',\n')}];
+
 export default function AppRouter() {
   const isDev = process.env.NODE_ENV !== 'production';
   const content = (


### PR DESCRIPTION
## Summary

- Restore the missing `const routes = [...]` declaration in the auto-generated AppRouter template.
- Fixes SSR dev error `ReferenceError: routes is not defined` introduced during the TypeScript migration of `appRouterPlugin.ts`.

## Test plan

- [x] `pnpm run format:check`
- [x] `pnpm --filter @unsetsoft/ryunix-presets run test`
- [x] Manual: `ryunix dev` in `test/webpack2` — SSR responds 200 without render error
